### PR TITLE
Bruk getRouteApi slik at HMR fungerer

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: https://npm.pkg.github.com/
+          scope: '@navikt'
           cache-dependency-path: app
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/verify-server.yml
+++ b/.github/workflows/verify-server.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'npm'
           registry-url: https://npm.pkg.github.com/
           scope: '@navikt'
-          cache-dependency-path: app
+          cache-dependency-path: server
 
       - name: Install dependencies
         run: npm ci

--- a/app/src/views/endre-inntektsmelding/EndreInntektsmelding.tsx
+++ b/app/src/views/endre-inntektsmelding/EndreInntektsmelding.tsx
@@ -1,12 +1,14 @@
 import { BodyLong } from "@navikt/ds-react";
 import { setBreadcrumbs } from "@navikt/nav-dekoratoren-moduler";
+import { getRouteApi } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { RotLayout } from "~/features/rot-layout/RotLayout";
-import { Route } from "~/routes/endre.$id";
+
+const route = getRouteApi("/endre/$id");
 
 export const EndreInntektsmelding = () => {
-  const { id } = Route.useParams();
+  const { id } = route.useParams();
   useEffect(() => {
     setBreadcrumbs([
       {

--- a/app/src/views/kvittering/Kvittering.tsx
+++ b/app/src/views/kvittering/Kvittering.tsx
@@ -1,12 +1,14 @@
 import { BodyLong } from "@navikt/ds-react";
 import { setBreadcrumbs } from "@navikt/nav-dekoratoren-moduler";
+import { getRouteApi } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { RotLayout } from "~/features/rot-layout/RotLayout";
-import { Route } from "~/routes/kvittering.$id";
+
+const route = getRouteApi("/kvittering/$id");
 
 export const Kvittering = () => {
-  const { id } = Route.useParams();
+  const { id } = route.useParams();
   useEffect(() => {
     setBreadcrumbs([
       {

--- a/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
+++ b/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
@@ -1,12 +1,14 @@
 import { BodyLong } from "@navikt/ds-react";
 import { setBreadcrumbs } from "@navikt/nav-dekoratoren-moduler";
+import { getRouteApi } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { RotLayout } from "~/features/rot-layout/RotLayout";
-import { Route } from "~/routes/ny.$id";
+
+const route = getRouteApi("/ny/$id");
 
 export const NyInntektsmelding = () => {
-  const { id } = Route.useParams();
+  const { id } = route.useParams();
   useEffect(() => {
     setBreadcrumbs([
       {


### PR DESCRIPTION
Enten må man ha components i samme fil som ruta, eller så må man bruke et eget API for å få tak i ruta, siden å importere den fører til sirkulære avhengigheter, og det gjør at vite gjør en hard reload istedenfor HMR på endringer.

https://tanstack.com/router/latest/docs/framework/react/guide/code-splitting#manually-accessing-route-apis-in-other-files-with-the-routeapi-class