### PR TITLE
Bruk loaders til å hente data istedenfor tanstack query

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,7 +19,8 @@
         "date-fns": "3.6.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-hook-form": "7.51.4"
+        "react-hook-form": "7.51.4",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@navikt/aksel-stylelint": "6.10.0",
@@ -8493,7 +8494,6 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,8 @@
     "date-fns": "3.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-hook-form": "7.51.4"
+    "react-hook-form": "7.51.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@navikt/aksel-stylelint": "6.10.0",

--- a/app/src/api/queries.ts
+++ b/app/src/api/queries.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 const SERVER_URL = `${import.meta.env.BASE_URL}/server/api`;
 
-export async function hentForespørselData(uuid: string) {
+export async function hentOpplysningerData(uuid: string) {
   const response = await fetch(
     `${SERVER_URL}/imdialog/grunnlag?foresporselUuid=${uuid}`,
     {
@@ -18,7 +18,7 @@ export async function hentForespørselData(uuid: string) {
     throw new Error("Kunne ikke hente forespørsel");
   }
   const json = await response.json();
-  const parsedJson = forespørselSchema.safeParse(json);
+  const parsedJson = opplysningerSchema.safeParse(json);
 
   if (!parsedJson.success) {
     // TODO: Har med en error-logger her, bør fjernes før vi går i prod
@@ -29,7 +29,7 @@ export async function hentForespørselData(uuid: string) {
   return parsedJson.data;
 }
 
-const forespørselSchema = z.object({
+const opplysningerSchema = z.object({
   person: z.object({
     aktørId: z.string(),
     fødselsnummer: z.string(),
@@ -60,4 +60,4 @@ const forespørselSchema = z.object({
   ]),
 });
 
-export type ForespørselDto = z.infer<typeof forespørselSchema>;
+export type OpplysningerDto = z.infer<typeof opplysningerSchema>;

--- a/app/src/api/queries.ts
+++ b/app/src/api/queries.ts
@@ -1,28 +1,61 @@
-import { queryOptions } from "@tanstack/react-query";
-
-import type { InntektsmeldingDialogDto } from "~/types/api-models";
+import { z } from "zod";
 
 const SERVER_URL = `${import.meta.env.BASE_URL}/server/api`;
 
-export function forespørselQueryOptions(forespørselUUID: string) {
-  return queryOptions({
-    queryKey: ["FORESPØRSEL", forespørselUUID],
-    queryFn: async () => {
-      const response = await fetch(
-        `${SERVER_URL}/imdialog/grunnlag?foresporselUuid=${forespørselUUID}`,
-        {
-          headers: {
-            "nav-consumer-id": "ft-inntektsmelding-frontend", // TODO: Kan fjernes når backend har skrudd på auth
-          },
-        },
-      );
-      if (response.status === 404) {
-        throw new Error("Forespørsel ikke funnet");
-      }
-      if (!response.ok) {
-        throw new Error("Kunne ikke hente forespørsel");
-      }
-      return (await response.json()) as InntektsmeldingDialogDto;
+export async function hentForespørselData(uuid: string) {
+  const response = await fetch(
+    `${SERVER_URL}/imdialog/grunnlag?foresporselUuid=${uuid}`,
+    {
+      headers: {
+        "nav-consumer-id": "ft-inntektsmelding-frontend", // TODO: Kan fjernes når backend har skrudd på auth
+      },
     },
-  });
+  );
+  if (response.status === 404) {
+    throw new Error("Forespørsel ikke funnet");
+  }
+  if (!response.ok) {
+    throw new Error("Kunne ikke hente forespørsel");
+  }
+  const json = await response.json();
+  const parsedJson = forespørselSchema.safeParse(json);
+
+  if (!parsedJson.success) {
+    // TODO: Har med en error-logger her, bør fjernes før vi går i prod
+    // eslint-disable-next-line no-console
+    console.error(parsedJson.error);
+    throw new Error("Responsen fra serveren matchet ikke forventet format");
+  }
+  return parsedJson.data;
 }
+
+const forespørselSchema = z.object({
+  person: z.object({
+    aktørId: z.string(),
+    fødselsnummer: z.string(),
+    navn: z.string(),
+  }),
+  arbeidsgiver: z.object({
+    organisasjonNavn: z.string(),
+    organisasjonNummer: z.string(),
+  }),
+  inntekter: z
+    .array(
+      z.object({
+        fom: z.string(),
+        tom: z.string(),
+        beløp: z.number(),
+        arbeidsgiverIdent: z.string(),
+      }),
+    )
+    .optional(),
+  startdatoPermisjon: z.string(),
+  ytelse: z.enum([
+    "FORELDREPENGER",
+    "SVANGERSKAPSPENGER",
+    "PLEIEPENGER_SYKT_BARN",
+    "PLEIEPENGER_I_LIVETS_SLUTTFASE",
+    "OPPLÆRINGSPENGER",
+    "OMSORGSPENGER",
+  ]),
+});

--- a/app/src/api/queries.ts
+++ b/app/src/api/queries.ts
@@ -59,3 +59,5 @@ const forespørselSchema = z.object({
     "OMSORGSPENGER",
   ]),
 });
+
+export type ForespørselDto = z.infer<typeof forespørselSchema>;

--- a/app/src/features/skjema-moduler/Inntekt.tsx
+++ b/app/src/features/skjema-moduler/Inntekt.tsx
@@ -14,15 +14,13 @@ import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 import { Fragment } from "react";
 
+import type { ForespørselDto } from "~/api/queries";
 import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
-import type {
-  InntektsmeldingDialogDto,
-  MånedsinntektResponsDto,
-} from "~/types/api-models.ts";
+import type { MånedsinntektResponsDto } from "~/types/api-models.ts";
 import { capitalizeSetning, formatKroner, leggTilGenitiv } from "~/utils.ts";
 
 type InntektProps = {
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 export function Inntekt({ inntektsmeldingDialogDto }: InntektProps) {
   const { startdatoPermisjon, person, inntekter } = inntektsmeldingDialogDto;

--- a/app/src/features/skjema-moduler/Inntekt.tsx
+++ b/app/src/features/skjema-moduler/Inntekt.tsx
@@ -14,16 +14,16 @@ import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 import { Fragment } from "react";
 
-import type { ForespørselDto } from "~/api/queries";
+import type { OpplysningerDto } from "~/api/queries";
 import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
 import type { MånedsinntektResponsDto } from "~/types/api-models.ts";
 import { capitalizeSetning, formatKroner, leggTilGenitiv } from "~/utils.ts";
 
 type InntektProps = {
-  forespørsel: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
-export function Inntekt({ forespørsel }: InntektProps) {
-  const { startdatoPermisjon, person, inntekter } = forespørsel;
+export function Inntekt({ opplysninger }: InntektProps) {
+  const { startdatoPermisjon, person, inntekter } = opplysninger;
 
   const førsteDag = capitalizeSetning(
     format(startdatoPermisjon, "dd.MM yyyy", {

--- a/app/src/features/skjema-moduler/Inntekt.tsx
+++ b/app/src/features/skjema-moduler/Inntekt.tsx
@@ -20,10 +20,10 @@ import type { MånedsinntektResponsDto } from "~/types/api-models.ts";
 import { capitalizeSetning, formatKroner, leggTilGenitiv } from "~/utils.ts";
 
 type InntektProps = {
-  inntektsmeldingDialogDto: ForespørselDto;
+  forespørsel: ForespørselDto;
 };
-export function Inntekt({ inntektsmeldingDialogDto }: InntektProps) {
-  const { startdatoPermisjon, person, inntekter } = inntektsmeldingDialogDto;
+export function Inntekt({ forespørsel }: InntektProps) {
+  const { startdatoPermisjon, person, inntekter } = forespørsel;
 
   const førsteDag = capitalizeSetning(
     format(startdatoPermisjon, "dd.MM yyyy", {

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -16,7 +16,7 @@ import { useNavigate } from "@tanstack/react-router";
 import clsx from "clsx";
 import { useForm } from "react-hook-form";
 
-import type { ForespørselDto } from "~/api/queries";
+import type { OpplysningerDto } from "~/api/queries";
 import {
   type InntektsmeldingSkjemaState,
   useInntektsmeldingSkjema,
@@ -30,10 +30,10 @@ type PersonOgSelskapsInformasjonForm = NonNullable<
 
 type PersonOgSelskapsInformasjonSeksjonProps = {
   className?: string;
-  forespørsel: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
 export const PersonOgSelskapsInformasjonSeksjon = ({
-  forespørsel,
+  opplysninger,
   className,
 }: PersonOgSelskapsInformasjonSeksjonProps) => {
   const { inntektsmeldingSkjemaState, setInntektsmeldingSkjemaState } =
@@ -66,9 +66,9 @@ export const PersonOgSelskapsInformasjonSeksjon = ({
           </Heading>
           <Fremgangsindikator aktivtSteg={1} />
 
-          <Intro forespørsel={forespørsel} />
-          <ArbeidsgiverInformasjon forespørsel={forespørsel} />
-          <Personinformasjon forespørsel={forespørsel} />
+          <Intro opplysninger={opplysninger} />
+          <ArbeidsgiverInformasjon opplysninger={opplysninger} />
+          <Personinformasjon opplysninger={opplysninger} />
 
           <InformasjonsseksjonMedKilde
             className="col-span-2"
@@ -132,10 +132,10 @@ export const PersonOgSelskapsInformasjonSeksjon = ({
 };
 
 type IntroProps = {
-  forespørsel: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
-const Intro = ({ forespørsel }: IntroProps) => {
-  const { person, arbeidsgiver } = forespørsel;
+const Intro = ({ opplysninger }: IntroProps) => {
+  const { person, arbeidsgiver } = opplysninger;
   const [fornavn] = person.navn.split(" ") ?? ["den ansatte"];
   return (
     <GuidePanel className="mb-4 col-span-2">
@@ -163,11 +163,11 @@ const Intro = ({ forespørsel }: IntroProps) => {
 };
 
 type PersoninformasjonProps = {
-  forespørsel: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
 
-const Personinformasjon = ({ forespørsel }: PersoninformasjonProps) => {
-  const { person } = forespørsel;
+const Personinformasjon = ({ opplysninger }: PersoninformasjonProps) => {
+  const { person } = opplysninger;
 
   return (
     <InformasjonsseksjonMedKilde kilde="Fra søknad" tittel="Den ansatte">
@@ -190,12 +190,12 @@ const formaterFødselsnummer = (str: string) => {
 };
 
 type ArbeidsgiverInformasjonProps = {
-  forespørsel: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
 const ArbeidsgiverInformasjon = ({
-  forespørsel,
+  opplysninger,
 }: ArbeidsgiverInformasjonProps) => {
-  const { arbeidsgiver } = forespørsel;
+  const { arbeidsgiver } = opplysninger;
 
   return (
     <InformasjonsseksjonMedKilde kilde="Fra Altinn" tittel="Arbeidsgiver">

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -16,11 +16,11 @@ import { useNavigate } from "@tanstack/react-router";
 import clsx from "clsx";
 import { useForm } from "react-hook-form";
 
+import type { ForespørselDto } from "~/api/queries";
 import {
   type InntektsmeldingSkjemaState,
   useInntektsmeldingSkjema,
 } from "~/features/InntektsmeldingSkjemaState";
-import type { InntektsmeldingDialogDto } from "~/types/api-models.ts";
 
 import { Fremgangsindikator } from "./Fremgangsindikator";
 
@@ -30,7 +30,7 @@ type PersonOgSelskapsInformasjonForm = NonNullable<
 
 type PersonOgSelskapsInformasjonSeksjonProps = {
   className?: string;
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 export const PersonOgSelskapsInformasjonSeksjon = ({
   inntektsmeldingDialogDto,
@@ -136,7 +136,7 @@ export const PersonOgSelskapsInformasjonSeksjon = ({
 };
 
 type IntroProps = {
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 const Intro = ({ inntektsmeldingDialogDto }: IntroProps) => {
   const { person, arbeidsgiver } = inntektsmeldingDialogDto;
@@ -167,7 +167,7 @@ const Intro = ({ inntektsmeldingDialogDto }: IntroProps) => {
 };
 
 type PersoninformasjonProps = {
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 
 const Personinformasjon = ({
@@ -196,7 +196,7 @@ const formaterFødselsnummer = (str: string) => {
 };
 
 type ArbeidsgiverInformasjonProps = {
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 const ArbeidsgiverInformasjon = ({
   inntektsmeldingDialogDto,

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -30,10 +30,10 @@ type PersonOgSelskapsInformasjonForm = NonNullable<
 
 type PersonOgSelskapsInformasjonSeksjonProps = {
   className?: string;
-  inntektsmeldingDialogDto: ForespørselDto;
+  forespørsel: ForespørselDto;
 };
 export const PersonOgSelskapsInformasjonSeksjon = ({
-  inntektsmeldingDialogDto,
+  forespørsel,
   className,
 }: PersonOgSelskapsInformasjonSeksjonProps) => {
   const { inntektsmeldingSkjemaState, setInntektsmeldingSkjemaState } =
@@ -66,13 +66,9 @@ export const PersonOgSelskapsInformasjonSeksjon = ({
           </Heading>
           <Fremgangsindikator aktivtSteg={1} />
 
-          <Intro inntektsmeldingDialogDto={inntektsmeldingDialogDto} />
-          <ArbeidsgiverInformasjon
-            inntektsmeldingDialogDto={inntektsmeldingDialogDto}
-          />
-          <Personinformasjon
-            inntektsmeldingDialogDto={inntektsmeldingDialogDto}
-          />
+          <Intro forespørsel={forespørsel} />
+          <ArbeidsgiverInformasjon forespørsel={forespørsel} />
+          <Personinformasjon forespørsel={forespørsel} />
 
           <InformasjonsseksjonMedKilde
             className="col-span-2"
@@ -136,10 +132,10 @@ export const PersonOgSelskapsInformasjonSeksjon = ({
 };
 
 type IntroProps = {
-  inntektsmeldingDialogDto: ForespørselDto;
+  forespørsel: ForespørselDto;
 };
-const Intro = ({ inntektsmeldingDialogDto }: IntroProps) => {
-  const { person, arbeidsgiver } = inntektsmeldingDialogDto;
+const Intro = ({ forespørsel }: IntroProps) => {
+  const { person, arbeidsgiver } = forespørsel;
   const [fornavn] = person.navn.split(" ") ?? ["den ansatte"];
   return (
     <GuidePanel className="mb-4 col-span-2">
@@ -167,13 +163,11 @@ const Intro = ({ inntektsmeldingDialogDto }: IntroProps) => {
 };
 
 type PersoninformasjonProps = {
-  inntektsmeldingDialogDto: ForespørselDto;
+  forespørsel: ForespørselDto;
 };
 
-const Personinformasjon = ({
-  inntektsmeldingDialogDto,
-}: PersoninformasjonProps) => {
-  const { person } = inntektsmeldingDialogDto;
+const Personinformasjon = ({ forespørsel }: PersoninformasjonProps) => {
+  const { person } = forespørsel;
 
   return (
     <InformasjonsseksjonMedKilde kilde="Fra søknad" tittel="Den ansatte">
@@ -196,12 +190,12 @@ const formaterFødselsnummer = (str: string) => {
 };
 
 type ArbeidsgiverInformasjonProps = {
-  inntektsmeldingDialogDto: ForespørselDto;
+  forespørsel: ForespørselDto;
 };
 const ArbeidsgiverInformasjon = ({
-  inntektsmeldingDialogDto,
+  forespørsel,
 }: ArbeidsgiverInformasjonProps) => {
-  const { arbeidsgiver } = inntektsmeldingDialogDto;
+  const { arbeidsgiver } = forespørsel;
 
   return (
     <InformasjonsseksjonMedKilde kilde="Fra Altinn" tittel="Arbeidsgiver">

--- a/app/src/routes/$id.dine-opplysninger.tsx
+++ b/app/src/routes/$id.dine-opplysninger.tsx
@@ -1,17 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { hentForespørselData } from "~/api/queries.ts";
+import { hentOpplysningerData } from "~/api/queries.ts";
 import { PersonOgSelskapsInformasjonSeksjon } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
 
 const DineOpplysninger = () => {
   const data = Route.useLoaderData();
 
   return (
-    <PersonOgSelskapsInformasjonSeksjon className="mt-6" forespørsel={data} />
+    <PersonOgSelskapsInformasjonSeksjon className="mt-6" opplysninger={data} />
   );
 };
 
 export const Route = createFileRoute("/$id/dine-opplysninger")({
   component: DineOpplysninger,
-  loader: ({ params }) => hentForespørselData(params.id),
+  loader: ({ params }) => hentOpplysningerData(params.id),
 });

--- a/app/src/routes/$id.dine-opplysninger.tsx
+++ b/app/src/routes/$id.dine-opplysninger.tsx
@@ -1,23 +1,20 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
-import { forespørselQueryOptions } from "~/api/queries.ts";
+import { hentForespørselData } from "~/api/queries.ts";
 import { PersonOgSelskapsInformasjonSeksjon } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
 
 const DineOpplysninger = () => {
-  const { id } = Route.useParams();
-  const inntektsmeldingDialogDto = useSuspenseQuery(
-    forespørselQueryOptions(id),
-  ).data;
+  const data = Route.useLoaderData();
 
   return (
     <PersonOgSelskapsInformasjonSeksjon
       className="mt-6"
-      inntektsmeldingDialogDto={inntektsmeldingDialogDto}
+      inntektsmeldingDialogDto={data}
     />
   );
 };
 
 export const Route = createFileRoute("/$id/dine-opplysninger")({
   component: DineOpplysninger,
+  loader: ({ params }) => hentForespørselData(params.id),
 });

--- a/app/src/routes/$id.dine-opplysninger.tsx
+++ b/app/src/routes/$id.dine-opplysninger.tsx
@@ -7,10 +7,7 @@ const DineOpplysninger = () => {
   const data = Route.useLoaderData();
 
   return (
-    <PersonOgSelskapsInformasjonSeksjon
-      className="mt-6"
-      inntektsmeldingDialogDto={data}
-    />
+    <PersonOgSelskapsInformasjonSeksjon className="mt-6" forespørsel={data} />
   );
 };
 

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -8,12 +8,11 @@ import {
   ReadMore,
   VStack,
 } from "@navikt/ds-react";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 
-import { forespørselQueryOptions } from "~/api/queries.ts";
+import { hentForespørselData } from "~/api/queries.ts";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator.tsx";
 import { Inntekt } from "~/features/skjema-moduler/Inntekt.tsx";
 import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
@@ -22,13 +21,11 @@ import { capitalizeSetning, leggTilGenitiv } from "~/utils.ts";
 
 export const Route = createFileRoute("/$id/inntekt-og-refusjon")({
   component: InntektOgRefusjon,
+  loader: ({ params }) => hentForespørselData(params.id),
 });
 
 function InntektOgRefusjon() {
-  const { id } = Route.useParams();
-  const inntektsmeldingDialogDto = useSuspenseQuery(
-    forespørselQueryOptions(id),
-  ).data;
+  const inntektsmeldingDialogDto = Route.useLoaderData();
 
   return (
     <section className="mt-6">

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -12,11 +12,11 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 
+import type { ForespørselDto } from "~/api/queries.ts";
 import { hentForespørselData } from "~/api/queries.ts";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator.tsx";
 import { Inntekt } from "~/features/skjema-moduler/Inntekt.tsx";
 import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
-import type { InntektsmeldingDialogDto } from "~/types/api-models.ts";
 import { capitalizeSetning, leggTilGenitiv } from "~/utils.ts";
 
 export const Route = createFileRoute("/$id/inntekt-og-refusjon")({
@@ -64,7 +64,7 @@ function InntektOgRefusjon() {
 }
 
 type ForeldrepengePeriodeProps = {
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 function ForeldrepengePeriode({
   inntektsmeldingDialogDto,

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -12,8 +12,8 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { nb } from "date-fns/locale";
 
-import type { ForespørselDto } from "~/api/queries.ts";
-import { hentForespørselData } from "~/api/queries.ts";
+import type { OpplysningerDto } from "~/api/queries.ts";
+import { hentOpplysningerData } from "~/api/queries.ts";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator.tsx";
 import { Inntekt } from "~/features/skjema-moduler/Inntekt.tsx";
 import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
@@ -21,11 +21,11 @@ import { capitalizeSetning, leggTilGenitiv } from "~/utils.ts";
 
 export const Route = createFileRoute("/$id/inntekt-og-refusjon")({
   component: InntektOgRefusjon,
-  loader: ({ params }) => hentForespørselData(params.id),
+  loader: ({ params }) => hentOpplysningerData(params.id),
 });
 
 function InntektOgRefusjon() {
-  const inntektsmeldingDialogDto = Route.useLoaderData();
+  const opplysninger = Route.useLoaderData();
 
   return (
     <section className="mt-6">
@@ -34,10 +34,8 @@ function InntektOgRefusjon() {
           Inntekt og refusjon
         </Heading>
         <Fremgangsindikator aktivtSteg={2} />
-        <ForeldrepengePeriode
-          inntektsmeldingDialogDto={inntektsmeldingDialogDto}
-        />
-        <Inntekt forespørsel={inntektsmeldingDialogDto} />
+        <ForeldrepengePeriode opplysninger={opplysninger} />
+        <Inntekt opplysninger={opplysninger} />
         <UtbetalingOgRefusjon />
         <Naturalytelser />
         <div className="flex gap-4 justify-center">
@@ -64,12 +62,10 @@ function InntektOgRefusjon() {
 }
 
 type ForeldrepengePeriodeProps = {
-  inntektsmeldingDialogDto: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
-function ForeldrepengePeriode({
-  inntektsmeldingDialogDto,
-}: ForeldrepengePeriodeProps) {
-  const { startdatoPermisjon, person } = inntektsmeldingDialogDto;
+function ForeldrepengePeriode({ opplysninger }: ForeldrepengePeriodeProps) {
+  const { startdatoPermisjon, person } = opplysninger;
 
   const førsteDag = capitalizeSetning(
     format(startdatoPermisjon, "EEEE dd.MMMM yyyy", {

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -37,7 +37,7 @@ function InntektOgRefusjon() {
         <ForeldrepengePeriode
           inntektsmeldingDialogDto={inntektsmeldingDialogDto}
         />
-        <Inntekt inntektsmeldingDialogDto={inntektsmeldingDialogDto} />
+        <Inntekt forespørsel={inntektsmeldingDialogDto} />
         <UtbetalingOgRefusjon />
         <Naturalytelser />
         <div className="flex gap-4 justify-center">

--- a/app/src/routes/$id.kvittering.tsx
+++ b/app/src/routes/$id.kvittering.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { hentForespørselData } from "~/api/queries";
+import { hentOpplysningerData } from "~/api/queries";
 import { Kvittering } from "~/views/kvittering/Kvittering";
 
 export const Route = createFileRoute("/$id/kvittering")({
   component: Kvittering,
-  loader: ({ params }) => hentForespørselData(params.id),
+  loader: ({ params }) => hentOpplysningerData(params.id),
 });

--- a/app/src/routes/$id.kvittering.tsx
+++ b/app/src/routes/$id.kvittering.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { hentForespørselData } from "~/api/queries";
 import { Kvittering } from "~/views/kvittering/Kvittering";
 
 export const Route = createFileRoute("/$id/kvittering")({
   component: Kvittering,
+  loader: ({ params }) => hentForespørselData(params.id),
 });

--- a/app/src/routes/$id.oppsummering.tsx
+++ b/app/src/routes/$id.oppsummering.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { hentForespørselData } from "~/api/queries";
 import { Oppsummering } from "~/views/oppsummering/Oppsummering";
 
 export const Route = createFileRoute("/$id/oppsummering")({
   component: Oppsummering,
+  loader: ({ params }) => hentForespørselData(params.id),
 });

--- a/app/src/routes/$id.oppsummering.tsx
+++ b/app/src/routes/$id.oppsummering.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { hentForespørselData } from "~/api/queries";
+import { hentOpplysningerData } from "~/api/queries";
 import { Oppsummering } from "~/views/oppsummering/Oppsummering";
 
 export const Route = createFileRoute("/$id/oppsummering")({
   component: Oppsummering,
-  loader: ({ params }) => hentForespørselData(params.id),
+  loader: ({ params }) => hentOpplysningerData(params.id),
 });

--- a/app/src/routes/$id.tsx
+++ b/app/src/routes/$id.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { forespørselQueryOptions } from "~/api/queries.ts";
+import { hentForespørselData } from "~/api/queries.ts";
 import { NyInntektsmelding } from "~/views/ny-inntektsmelding/NyInntektsmelding";
 
 export const Route = createFileRoute("/$id")({
   component: NyInntektsmelding,
-  loader: ({ context, params }) =>
-    context.queryClient.prefetchQuery(forespørselQueryOptions(params.id)),
+  loader: ({ params }) => hentForespørselData(params.id),
 });

--- a/app/src/routes/$id.tsx
+++ b/app/src/routes/$id.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { hentForespørselData } from "~/api/queries.ts";
+import { hentOpplysningerData } from "~/api/queries.ts";
 import { NyInntektsmelding } from "~/views/ny-inntektsmelding/NyInntektsmelding";
 
 export const Route = createFileRoute("/$id")({
   component: NyInntektsmelding,
-  loader: ({ params }) => hentForespørselData(params.id),
+  loader: ({ params }) => hentOpplysningerData(params.id),
 });

--- a/app/src/types/api-models.ts
+++ b/app/src/types/api-models.ts
@@ -1,26 +1,8 @@
-export type PersonInfoDto = {
-  aktørId: string;
-  fødselsnummer: string;
-  navn: string;
-};
-
-export type OrganisasjonInfoDto = {
-  organisasjonNavn: string;
-  organisasjonNummer: string;
-};
-
 export type MånedsinntektResponsDto = {
   fom: string;
   tom: string;
   beløp: number;
   arbeidsgiverIdent: string;
-};
-
-export type HentInntektRequestDto = {
-  aktorId: string;
-  ytelse: Ytelsetype;
-  arbeidsgiverIdent: string;
-  startdato: string;
 };
 
 export type Ytelsetype =
@@ -75,24 +57,4 @@ type NaturalytelseRequestDto = {
   tom: string;
   beløp: number;
   naturalytelsetype: Naturalytelsetype;
-};
-
-export type InntektsmeldingDialogDto = {
-  person: PersonInfoDto;
-  arbeidsgiver: OrganisasjonInfoDto;
-  inntekter?: MånedsinntektResponsDto[]; // Dette burde være empty list fra backend, men en bug gjør at feltet ikke kommer med.
-  startdatoPermisjon: string;
-  ytelse: Ytelsetype;
-};
-
-export type ForespørselEntitet = {
-  id: number;
-  uuid: string;
-  sakId: string;
-  oppgaveId: string;
-  organisasjonsnummer: string;
-  skjæringstidspunkt: string;
-  brukerAktørId: string;
-  ytelseType: Ytelsetype;
-  fagsystemSaksnummer: string;
 };

--- a/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
+++ b/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
@@ -1,9 +1,7 @@
 import { setBreadcrumbs } from "@navikt/nav-dekoratoren-moduler";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { getRouteApi, Outlet } from "@tanstack/react-router";
 import { useEffect } from "react";
 
-import { forespørselQueryOptions } from "~/api/queries.ts";
 import { RotLayout } from "~/features/rot-layout/RotLayout";
 import { capitalizeSetning, formatYtelsesnavn } from "~/utils.ts";
 
@@ -11,10 +9,7 @@ const route = getRouteApi("/$id");
 
 export const NyInntektsmelding = () => {
   const { id } = route.useParams();
-
-  const inntektsmeldingDialogDto = useSuspenseQuery(
-    forespørselQueryOptions(id),
-  ).data;
+  const inntektsmeldingDialogDto = route.useLoaderData();
 
   useEffect(() => {
     setBreadcrumbs([

--- a/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
+++ b/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
@@ -9,7 +9,7 @@ const route = getRouteApi("/$id");
 
 export const NyInntektsmelding = () => {
   const { id } = route.useParams();
-  const inntektsmeldingDialogDto = route.useLoaderData();
+  const forespørsel = route.useLoaderData();
 
   useEffect(() => {
     setBreadcrumbs([
@@ -26,12 +26,12 @@ export const NyInntektsmelding = () => {
 
   return (
     <RotLayout
-      tittel={`Inntektsmelding ${formatYtelsesnavn(inntektsmeldingDialogDto.ytelse)}`}
+      tittel={`Inntektsmelding ${formatYtelsesnavn(forespørsel.ytelse)}`}
       undertittel={
         <div className="flex gap-3">
-          <span>{inntektsmeldingDialogDto.arbeidsgiver.organisasjonNavn}</span>
+          <span>{forespørsel.arbeidsgiver.organisasjonNavn}</span>
           <span>|</span>
-          <span>{capitalizeSetning(inntektsmeldingDialogDto.person.navn)}</span>
+          <span>{capitalizeSetning(forespørsel.person.navn)}</span>
         </div>
       }
     >

--- a/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
+++ b/app/src/views/ny-inntektsmelding/NyInntektsmelding.tsx
@@ -9,7 +9,7 @@ const route = getRouteApi("/$id");
 
 export const NyInntektsmelding = () => {
   const { id } = route.useParams();
-  const forespørsel = route.useLoaderData();
+  const opplysninger = route.useLoaderData();
 
   useEffect(() => {
     setBreadcrumbs([
@@ -26,12 +26,12 @@ export const NyInntektsmelding = () => {
 
   return (
     <RotLayout
-      tittel={`Inntektsmelding ${formatYtelsesnavn(forespørsel.ytelse)}`}
+      tittel={`Inntektsmelding ${formatYtelsesnavn(opplysninger.ytelse)}`}
       undertittel={
         <div className="flex gap-3">
-          <span>{forespørsel.arbeidsgiver.organisasjonNavn}</span>
+          <span>{opplysninger.arbeidsgiver.organisasjonNavn}</span>
           <span>|</span>
-          <span>{capitalizeSetning(forespørsel.person.navn)}</span>
+          <span>{capitalizeSetning(opplysninger.person.navn)}</span>
         </div>
       }
     >

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -6,7 +6,7 @@ import { getRouteApi, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { sendInntektsmelding } from "~/api/mutations.ts";
-import type { ForespørselDto } from "~/api/queries";
+import type { OpplysningerDto } from "~/api/queries";
 import type { InntektsmeldingSkjemaState } from "~/features/InntektsmeldingSkjemaState";
 import { useInntektsmeldingSkjema } from "~/features/InntektsmeldingSkjemaState";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator";
@@ -22,7 +22,7 @@ const route = getRouteApi("/$id/oppsummering");
 
 export const Oppsummering = () => {
   const { id } = route.useParams();
-  const forespørsel = route.useLoaderData();
+  const opplysninger = route.useLoaderData();
 
   useEffect(() => {
     setBreadcrumbs([
@@ -233,7 +233,7 @@ export const Oppsummering = () => {
             </FormSummary.Answer>
           </FormSummary.Answers>
         </FormSummary>
-        <SendInnInntektsmelding forespørsel={forespørsel} />
+        <SendInnInntektsmelding opplysninger={opplysninger} />
       </div>
     </section>
   );
@@ -249,18 +249,18 @@ const formatterKontaktperson = (
 };
 
 type SendInnInntektsmeldingProps = {
-  forespørsel: ForespørselDto;
+  opplysninger: OpplysningerDto;
 };
-function SendInnInntektsmelding({ forespørsel }: SendInnInntektsmeldingProps) {
+function SendInnInntektsmelding({ opplysninger }: SendInnInntektsmeldingProps) {
   const navigate = useNavigate();
 
   const DUMMY_IM = {
     foresporselUuid: "123", // TODO
-    aktorId: forespørsel.person.aktørId,
-    ytelse: forespørsel.ytelse,
-    arbeidsgiverIdent: forespørsel.arbeidsgiver.organisasjonNummer,
+    aktorId: opplysninger.person.aktørId,
+    ytelse: opplysninger.ytelse,
+    arbeidsgiverIdent: opplysninger.arbeidsgiver.organisasjonNummer,
     telefonnummer: "12345678",
-    startdato: forespørsel.startdatoPermisjon,
+    startdato: opplysninger.startdatoPermisjon,
     inntekt: 30_000,
     refusjonsperioder: [],
     bortfaltNaturaltytelsePerioder: [],

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -22,7 +22,7 @@ const route = getRouteApi("/$id/oppsummering");
 
 export const Oppsummering = () => {
   const { id } = route.useParams();
-  const inntektsmeldingDialogDto = route.useLoaderData();
+  const forespørsel = route.useLoaderData();
 
   useEffect(() => {
     setBreadcrumbs([
@@ -233,9 +233,7 @@ export const Oppsummering = () => {
             </FormSummary.Answer>
           </FormSummary.Answers>
         </FormSummary>
-        <SendInnInntektsmelding
-          inntektsmeldingDialogDto={inntektsmeldingDialogDto}
-        />
+        <SendInnInntektsmelding forespørsel={forespørsel} />
       </div>
     </section>
   );
@@ -251,20 +249,18 @@ const formatterKontaktperson = (
 };
 
 type SendInnInntektsmeldingProps = {
-  inntektsmeldingDialogDto: ForespørselDto;
+  forespørsel: ForespørselDto;
 };
-function SendInnInntektsmelding({
-  inntektsmeldingDialogDto,
-}: SendInnInntektsmeldingProps) {
+function SendInnInntektsmelding({ forespørsel }: SendInnInntektsmeldingProps) {
   const navigate = useNavigate();
 
   const DUMMY_IM = {
     foresporselUuid: "123", // TODO
-    aktorId: inntektsmeldingDialogDto.person.aktørId,
-    ytelse: inntektsmeldingDialogDto.ytelse,
-    arbeidsgiverIdent: inntektsmeldingDialogDto.arbeidsgiver.organisasjonNummer,
+    aktorId: forespørsel.person.aktørId,
+    ytelse: forespørsel.ytelse,
+    arbeidsgiverIdent: forespørsel.arbeidsgiver.organisasjonNummer,
     telefonnummer: "12345678",
-    startdato: inntektsmeldingDialogDto.startdatoPermisjon,
+    startdato: forespørsel.startdatoPermisjon,
     inntekt: 30_000,
     refusjonsperioder: [],
     bortfaltNaturaltytelsePerioder: [],

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -1,12 +1,11 @@
 import { ArrowLeftIcon, PaperplaneIcon } from "@navikt/aksel-icons";
 import { Alert, Button, FormSummary, Heading } from "@navikt/ds-react";
 import { setBreadcrumbs } from "@navikt/nav-dekoratoren-moduler";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { getRouteApi, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { sendInntektsmelding } from "~/api/mutations.ts";
-import { forespørselQueryOptions } from "~/api/queries.ts";
 import type { InntektsmeldingSkjemaState } from "~/features/InntektsmeldingSkjemaState";
 import { useInntektsmeldingSkjema } from "~/features/InntektsmeldingSkjemaState";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator";
@@ -25,10 +24,7 @@ const route = getRouteApi("/$id/oppsummering");
 
 export const Oppsummering = () => {
   const { id } = route.useParams();
-
-  const inntektsmeldingDialogDto = useSuspenseQuery(
-    forespørselQueryOptions(id),
-  ).data;
+  const inntektsmeldingDialogDto = route.useLoaderData();
 
   useEffect(() => {
     setBreadcrumbs([

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -6,13 +6,11 @@ import { getRouteApi, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { sendInntektsmelding } from "~/api/mutations.ts";
+import type { ForespørselDto } from "~/api/queries";
 import type { InntektsmeldingSkjemaState } from "~/features/InntektsmeldingSkjemaState";
 import { useInntektsmeldingSkjema } from "~/features/InntektsmeldingSkjemaState";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator";
-import type {
-  InntektsmeldingDialogDto,
-  SendInntektsmeldingRequestDto,
-} from "~/types/api-models.ts";
+import type { SendInntektsmeldingRequestDto } from "~/types/api-models.ts";
 import {
   formatDatoLang,
   formatIdentitetsnummer,
@@ -253,7 +251,7 @@ const formatterKontaktperson = (
 };
 
 type SendInnInntektsmeldingProps = {
-  inntektsmeldingDialogDto: InntektsmeldingDialogDto;
+  inntektsmeldingDialogDto: ForespørselDto;
 };
 function SendInnInntektsmelding({
   inntektsmeldingDialogDto,


### PR DESCRIPTION
Tanstack Query har innebygget støtte for å kunne hente data for oss (og cache det) via loaders.

Denne PRen implementerer dette, som fører til kode i alle fall jeg synes er lettere å forholde seg til.

OG en liten bonus – denne PRen introduserer også zod, som validerer responsen vi får fra serveren.