### PR TITLE
Koble opp mer av skjemaet med opplysninger

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -2,6 +2,7 @@ const IGNORED_UNICORN_RULES = {
   "unicorn/filename-case": "off",
   "unicorn/no-null": "off",
   "unicorn/prevent-abbreviations": "off",
+  "unicorn/no-nested-ternary": "off",
 };
 
 // eslint-disable-next-line unicorn/prefer-module,no-undef

--- a/app/src/features/InformasjonsseksjonMedKilde.tsx
+++ b/app/src/features/InformasjonsseksjonMedKilde.tsx
@@ -1,0 +1,32 @@
+import { Detail, Heading } from "@navikt/ds-react";
+import clsx from "clsx";
+
+type InformasjonsseksjonMedKildeProps = {
+  kilde: string;
+  tittel: string;
+  children: React.ReactNode;
+  className?: string;
+};
+export const InformasjonsseksjonMedKilde = ({
+  children,
+  kilde,
+  tittel,
+  className,
+}: InformasjonsseksjonMedKildeProps) => {
+  return (
+    <div
+      className={clsx(
+        "bg-bg-subtle p-4 flex flex-col gap-4 rounded-md",
+        className,
+      )}
+    >
+      <div className="flex justify-between items-center">
+        <Heading level="3" size="xsmall">
+          {tittel}
+        </Heading>
+        <Detail className="uppercase flex items-center">{kilde}</Detail>
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/app/src/features/skjema-moduler/Inntekt.tsx
+++ b/app/src/features/skjema-moduler/Inntekt.tsx
@@ -17,9 +17,10 @@ import {
   HjelpetekstAlert,
   HjelpetekstReadMore,
 } from "~/features/Hjelpetekst.tsx";
-import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
 import type { MånedsinntektResponsDto } from "~/types/api-models.ts";
 import { capitalizeSetning, formatKroner, leggTilGenitiv } from "~/utils.ts";
+
+import { InformasjonsseksjonMedKilde } from "../InformasjonsseksjonMedKilde";
 
 type InntektProps = {
   opplysninger: OpplysningerDto;

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -23,8 +23,8 @@ import {
 } from "~/features/InntektsmeldingSkjemaState";
 import { formatFødselsnummer } from "~/utils";
 
-import { Fremgangsindikator } from "./Fremgangsindikator";
 import { InformasjonsseksjonMedKilde } from "../InformasjonsseksjonMedKilde";
+import { Fremgangsindikator } from "./Fremgangsindikator";
 
 type PersonOgSelskapsInformasjonForm = NonNullable<
   InntektsmeldingSkjemaState["kontaktperson"]

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -21,6 +21,7 @@ import {
   type InntektsmeldingSkjemaState,
   useInntektsmeldingSkjema,
 } from "~/features/InntektsmeldingSkjemaState";
+import { formatFødselsnummer } from "~/utils";
 
 import { Fremgangsindikator } from "./Fremgangsindikator";
 
@@ -145,7 +146,7 @@ const Intro = ({ opplysninger }: IntroProps) => {
         </Heading>
         <BodyLong>
           <strong>
-            {person.navn} ({formaterFødselsnummer(person.fødselsnummer)})
+            {person.navn} ({formatFødselsnummer(person.fødselsnummer)})
           </strong>{" "}
           som jobber på <strong>{arbeidsgiver.organisasjonNavn}</strong> har
           søkt om foreldrepenger. NAV trenger derfor informasjon om inntekten
@@ -174,19 +175,12 @@ const Personinformasjon = ({ opplysninger }: PersoninformasjonProps) => {
       <LabelOgVerdi label="Navn">{person.navn}</LabelOgVerdi>
       <LabelOgVerdi label="Fødselsdato">
         <div className="flex items-center gap-2">
-          {formaterFødselsnummer(person.fødselsnummer)}{" "}
+          {formatFødselsnummer(person.fødselsnummer)}{" "}
           <CopyButton copyText={person.fødselsnummer} size="small" />
         </div>
       </LabelOgVerdi>
     </InformasjonsseksjonMedKilde>
   );
-};
-
-const formaterFødselsnummer = (str: string) => {
-  if (str?.length !== 11) {
-    return str;
-  }
-  return str.slice(0, 6) + " " + str.slice(6);
 };
 
 type ArbeidsgiverInformasjonProps = {

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -24,6 +24,7 @@ import {
 import { formatFødselsnummer } from "~/utils";
 
 import { Fremgangsindikator } from "./Fremgangsindikator";
+import { InformasjonsseksjonMedKilde } from "../InformasjonsseksjonMedKilde";
 
 type PersonOgSelskapsInformasjonForm = NonNullable<
   InntektsmeldingSkjemaState["kontaktperson"]
@@ -203,36 +204,6 @@ const ArbeidsgiverInformasjon = ({
   );
 };
 
-type InformasjonsseksjonMedKildeProps = {
-  kilde: string;
-  tittel: string;
-  children: React.ReactNode;
-  className?: string;
-};
-export const InformasjonsseksjonMedKilde = ({
-  children,
-  kilde,
-  tittel,
-  className,
-}: InformasjonsseksjonMedKildeProps) => {
-  return (
-    <div
-      className={clsx(
-        "bg-bg-subtle p-4 flex flex-col gap-4 rounded-md",
-        className,
-      )}
-    >
-      <div className="flex justify-between items-center">
-        <Heading level="3" size="xsmall">
-          {tittel}
-        </Heading>
-        <Detail className="uppercase flex items-center">{kilde}</Detail>
-      </div>
-      {children}
-    </div>
-  );
-};
-
 type LabelOgVerdiProps = {
   label: string;
   children: React.ReactNode;
@@ -243,7 +214,7 @@ const LabelOgVerdi = ({ label, children }: LabelOgVerdiProps) => {
       <Label as="p" size="small">
         {label}
       </Label>
-      <BodyShort>{children}</BodyShort>
+      <BodyShort as="div">{children}</BodyShort>
     </div>
   );
 };

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -5,7 +5,6 @@ import {
   BodyShort,
   Button,
   CopyButton,
-  Detail,
   GuidePanel,
   Heading,
   HGrid,
@@ -13,7 +12,6 @@ import {
   TextField,
 } from "@navikt/ds-react";
 import { useNavigate } from "@tanstack/react-router";
-import clsx from "clsx";
 import { useForm } from "react-hook-form";
 
 import type { OpplysningerDto } from "~/api/queries";

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -160,8 +160,8 @@ function Naturalytelser() {
       <RadioGroup
         error={formState.errors.misterNaturalytelser?.message}
         legend="Har den ansatte naturalytelser som faller bort ved fraværet?"
-        onChange={(value) => onChange({ target: { value } })}
         name={name}
+        onChange={(value) => onChange({ target: { value } })}
       >
         <Radio value="ja" {...radioGroupProps}>
           Ja
@@ -189,8 +189,8 @@ function UtbetalingOgRefusjon() {
       <RadioGroup
         error={formState.errors.skalRefunderes?.message}
         legend="Betaler dere lønn under fraværet og krever refusjon?"
-        onChange={(value) => onChange({ target: { value } })}
         name={name}
+        onChange={(value) => onChange({ target: { value } })}
       >
         <Radio value="ja" {...radioGroupProps}>
           Ja

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -14,10 +14,10 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import type { OpplysningerDto } from "~/api/queries.ts";
 import { hentOpplysningerData } from "~/api/queries.ts";
 import { HjelpetekstReadMore } from "~/features/Hjelpetekst";
+import { InformasjonsseksjonMedKilde } from "~/features/InformasjonsseksjonMedKilde";
 import { useInntektsmeldingSkjema } from "~/features/InntektsmeldingSkjemaState";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator.tsx";
 import { Inntekt } from "~/features/skjema-moduler/Inntekt.tsx";
-import { InformasjonsseksjonMedKilde } from "~/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx";
 import {
   capitalizeSetning,
   formatDatoLang,
@@ -136,6 +136,9 @@ function Ytelsesperiode({ opplysninger }: YtelsesperiodeProps) {
 
 function Naturalytelser() {
   const { register, formState } = useFormContext<InntektOgRefusjonForm>();
+  const { onChange, ...radioGroupProps } = register("misterNaturalytelser", {
+    required: "Du må svare på dette spørsmålet",
+  });
   return (
     <VStack gap="4">
       <hr />
@@ -152,11 +155,10 @@ function Naturalytelser() {
         </BodyLong>
       </HjelpetekstReadMore>
       <RadioGroup
-        legend="Har den ansatte naturalytelser som faller bort ved fraværet?"
-        {...register("misterNaturalytelser", {
-          required: "Du må svare på dette spørsmålet",
-        })}
         error={formState.errors.misterNaturalytelser?.message}
+        legend="Har den ansatte naturalytelser som faller bort ved fraværet?"
+        onChange={(value) => onChange({ target: { value } })}
+        {...radioGroupProps}
       >
         <Radio value="ja">Ja</Radio>
         <Radio value="nei">Nei</Radio>
@@ -167,6 +169,9 @@ function Naturalytelser() {
 
 function UtbetalingOgRefusjon() {
   const { register, formState } = useFormContext<InntektOgRefusjonForm>();
+  const { onChange, ...radioGroupProps } = register("skalRefunderes", {
+    required: "Du må svare på dette spørsmålet",
+  });
   return (
     <VStack gap="4">
       <hr />
@@ -175,11 +180,10 @@ function UtbetalingOgRefusjon() {
       </Heading>
       <ReadMore header="Hva vil det si å ha refusjon?">TODO</ReadMore>
       <RadioGroup
-        legend="Betaler dere lønn under fraværet og krever refusjon?"
-        {...register("skalRefunderes", {
-          required: "Du må svare på dette spørsmålet",
-        })}
         error={formState.errors.skalRefunderes?.message}
+        legend="Betaler dere lønn under fraværet og krever refusjon?"
+        onChange={(value) => onChange({ target: { value } })}
+        {...radioGroupProps}
       >
         <Radio value="ja">Ja</Radio>
         <Radio value="nei">Nei</Radio>

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -136,9 +136,12 @@ function Ytelsesperiode({ opplysninger }: YtelsesperiodeProps) {
 
 function Naturalytelser() {
   const { register, formState } = useFormContext<InntektOgRefusjonForm>();
-  const { onChange, ...radioGroupProps } = register("misterNaturalytelser", {
-    required: "Du må svare på dette spørsmålet",
-  });
+  const { onChange, name, ...radioGroupProps } = register(
+    "misterNaturalytelser",
+    {
+      required: "Du må svare på dette spørsmålet",
+    },
+  );
   return (
     <VStack gap="4">
       <hr />
@@ -158,10 +161,14 @@ function Naturalytelser() {
         error={formState.errors.misterNaturalytelser?.message}
         legend="Har den ansatte naturalytelser som faller bort ved fraværet?"
         onChange={(value) => onChange({ target: { value } })}
-        {...radioGroupProps}
+        name={name}
       >
-        <Radio value="ja">Ja</Radio>
-        <Radio value="nei">Nei</Radio>
+        <Radio value="ja" {...radioGroupProps}>
+          Ja
+        </Radio>
+        <Radio value="nei" {...radioGroupProps}>
+          Nei
+        </Radio>
       </RadioGroup>
     </VStack>
   );
@@ -169,7 +176,7 @@ function Naturalytelser() {
 
 function UtbetalingOgRefusjon() {
   const { register, formState } = useFormContext<InntektOgRefusjonForm>();
-  const { onChange, ...radioGroupProps } = register("skalRefunderes", {
+  const { onChange, name, ...radioGroupProps } = register("skalRefunderes", {
     required: "Du må svare på dette spørsmålet",
   });
   return (
@@ -183,10 +190,14 @@ function UtbetalingOgRefusjon() {
         error={formState.errors.skalRefunderes?.message}
         legend="Betaler dere lønn under fraværet og krever refusjon?"
         onChange={(value) => onChange({ target: { value } })}
-        {...radioGroupProps}
+        name={name}
       >
-        <Radio value="ja">Ja</Radio>
-        <Radio value="nei">Nei</Radio>
+        <Radio value="ja" {...radioGroupProps}>
+          Ja
+        </Radio>
+        <Radio value="nei" {...radioGroupProps}>
+          Nei
+        </Radio>
       </RadioGroup>
     </VStack>
   );

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -39,20 +39,13 @@ export function formatIsoDatostempel(dato: Date) {
   return `${år}-${måned}-${dag}`;
 }
 
-export function formatIdentitetsnummer(identitetsnummer: string) {
-  if (!/^\d{11}$/.test(identitetsnummer)) {
-    return identitetsnummer;
+export function formatFødselsnummer(fødselsnummer: string) {
+  if (!/^\d{11}$/.test(fødselsnummer)) {
+    return fødselsnummer;
   }
-  return `${identitetsnummer.slice(0, 6)} ${identitetsnummer.slice(6)}`;
+  return `${fødselsnummer.slice(0, 6)} ${fødselsnummer.slice(6)}`;
 }
 
 export function formatYtelsesnavn(ytelsesnavn: string) {
   return ytelsesnavn.toLowerCase().replace("_", " ");
-}
-
-export function formatFødselsnummer(str: string) {
-  if (str?.length !== 11) {
-    return str;
-  }
-  return `${str.slice(0, 6)} ${str.slice(6)}`;
 }

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -49,3 +49,10 @@ export function formatIdentitetsnummer(identitetsnummer: string) {
 export function formatYtelsesnavn(ytelsesnavn: string) {
   return ytelsesnavn.toLowerCase().replace("_", " ");
 }
+
+export function formatFødselsnummer(str: string) {
+  if (str?.length !== 11) {
+    return str;
+  }
+  return `${str.slice(0, 6)} ${str.slice(6)}`;
+}

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -13,7 +13,7 @@ import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator
 import type { SendInntektsmeldingRequestDto } from "~/types/api-models.ts";
 import {
   formatDatoLang,
-  formatIdentitetsnummer,
+  formatFødselsnummer,
   formatKroner,
   formatYtelsesnavn,
 } from "~/utils";
@@ -118,7 +118,7 @@ export const Oppsummering = () => {
               <FormSummary.Label>Den ansatte</FormSummary.Label>
               <FormSummary.Value>
                 {opplysninger.person.navn} (
-                {formatIdentitetsnummer(opplysninger.person.fødselsnummer)})
+                {formatFødselsnummer(opplysninger.person.fødselsnummer)})
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -23,6 +23,7 @@ const route = getRouteApi("/$id/oppsummering");
 export const Oppsummering = () => {
   const { id } = route.useParams();
   const opplysninger = route.useLoaderData();
+  const { inntektsmeldingSkjemaState } = useInntektsmeldingSkjema();
 
   useEffect(() => {
     setBreadcrumbs([
@@ -69,8 +70,6 @@ export const Oppsummering = () => {
     },
   };
 
-  const { inntektsmeldingSkjemaState } = useInntektsmeldingSkjema();
-
   return (
     <section>
       <div className="bg-bg-default mt-6 px-5 py-6 rounded-md flex flex-col gap-6">
@@ -93,7 +92,7 @@ export const Oppsummering = () => {
                   <FormSummary.Answer>
                     <FormSummary.Label>Virksomhetsnavn</FormSummary.Label>
                     <FormSummary.Value>
-                      {skjemadata.dineOpplysninger.arbeidsgiver.virksomhetsnavn}
+                      {opplysninger.arbeidsgiver.organisasjonNavn}
                     </FormSummary.Value>
                   </FormSummary.Answer>
                   <FormSummary.Answer>
@@ -101,10 +100,7 @@ export const Oppsummering = () => {
                       Org. nr. for underenhet
                     </FormSummary.Label>
                     <FormSummary.Value>
-                      {
-                        skjemadata.dineOpplysninger.arbeidsgiver
-                          .orgnrForUnderenhet
-                      }
+                      {opplysninger.arbeidsgiver.organisasjonNummer}
                     </FormSummary.Value>
                   </FormSummary.Answer>
                 </FormSummary.Answers>
@@ -121,12 +117,8 @@ export const Oppsummering = () => {
             <FormSummary.Answer>
               <FormSummary.Label>Den ansatte</FormSummary.Label>
               <FormSummary.Value>
-                {skjemadata.dineOpplysninger.arbeidstaker.fornavn}{" "}
-                {skjemadata.dineOpplysninger.arbeidstaker.etternavn} (
-                {formatIdentitetsnummer(
-                  skjemadata.dineOpplysninger.arbeidstaker.identitetsnummer,
-                )}
-                )
+                {opplysninger.person.navn} (
+                {formatIdentitetsnummer(opplysninger.person.fødselsnummer)})
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>
@@ -185,7 +177,7 @@ export const Oppsummering = () => {
                 refusjon fra NAV?
               </FormSummary.Label>
               <FormSummary.Value>
-                {skjemadata.inntektOgRefusjon.refusjon ? "Ja" : "Nei"}
+                {inntektsmeldingSkjemaState.skalRefunderes ? "Ja" : "Nei"}
               </FormSummary.Value>
             </FormSummary.Answer>
             {skjemadata.inntektOgRefusjon.refusjon && (
@@ -205,9 +197,7 @@ export const Oppsummering = () => {
                 permisjon?
               </FormSummary.Label>
               <FormSummary.Value>
-                {skjemadata.inntektOgRefusjon.refusjon?.endringIRefusjon
-                  ? "Ja"
-                  : "Nei"}
+                {inntektsmeldingSkjemaState.endringIRefusjon ? "Ja" : "Nei"}
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>
@@ -228,7 +218,7 @@ export const Oppsummering = () => {
                 naturalytelser som faller bort ved fraværet?
               </FormSummary.Label>
               <FormSummary.Value>
-                {skjemadata.inntektOgRefusjon.naturalytelser ? "Ja" : "Nei"}
+                {inntektsmeldingSkjemaState.misterNaturalytelser ? "Ja" : "Nei"}
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>


### PR DESCRIPTION
Denne ~pull requesten~ fletteforespørselen kobler opp litt flere felter til skjemaet, og bruker litt mer informasjon fra opplysninger-kallet.

Det var litt tricky å få radioknappene til å fungere med react-hook-form, så om du har noen gode innspill til hvordan det kan gjøres enklere, er jeg veldig åpen for innspill!