### PR TITLE
Redirect /$id til /$id/dine-opplysninger

### DIFF
--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -12,6 +12,7 @@
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as IdImport } from './routes/$id'
+import { Route as IdIndexImport } from './routes/$id.index'
 import { Route as EndreIdImport } from './routes/endre.$id'
 import { Route as IdOppsummeringImport } from './routes/$id.oppsummering'
 import { Route as IdKvitteringImport } from './routes/$id.kvittering'
@@ -23,6 +24,11 @@ import { Route as IdDineOpplysningerImport } from './routes/$id.dine-opplysninge
 const IdRoute = IdImport.update({
   path: '/$id',
   getParentRoute: () => rootRoute,
+} as any)
+
+const IdIndexRoute = IdIndexImport.update({
+  path: '/',
+  getParentRoute: () => IdRoute,
 } as any)
 
 const EndreIdRoute = EndreIdImport.update({
@@ -78,6 +84,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EndreIdImport
       parentRoute: typeof rootRoute
     }
+    '/$id/': {
+      preLoaderRoute: typeof IdIndexImport
+      parentRoute: typeof IdImport
+    }
   }
 }
 
@@ -89,6 +99,7 @@ export const routeTree = rootRoute.addChildren([
     IdInntektOgRefusjonRoute,
     IdKvitteringRoute,
     IdOppsummeringRoute,
+    IdIndexRoute,
   ]),
   EndreIdRoute,
 ])

--- a/app/src/routes/$id.index.tsx
+++ b/app/src/routes/$id.index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/$id/")({
-  component: () => null,
   loader: () => {
     throw redirect({ from: "/$id", to: "/$id/dine-opplysninger" });
   },

--- a/app/src/routes/$id.index.tsx
+++ b/app/src/routes/$id.index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/$id/")({
+  component: () => null,
+  loader: () => {
+    throw redirect({ from: "/$id", to: "/$id/dine-opplysninger" });
+  },
+});

--- a/app/src/routes/$id.tsx
+++ b/app/src/routes/$id.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/prefer-top-level-await */
 import { createFileRoute } from "@tanstack/react-router";
 
-import { hentOpplysningerData } from "~/api/queries.ts";
+import { hentOpplysningerData } from "~/api/queries";
 import { NyInntektsmelding } from "~/views/ny-inntektsmelding/NyInntektsmelding";
 
 export const Route = createFileRoute("/$id")({


### PR DESCRIPTION
Denne PRen legger til en redirect fra /$id til /$id/dine-opplysninger.

Hemmeligheten var å legge til en `$id.index.tsx` som gjorde redirecten i loaderen, mens man beholdt den eksisterende $id.tsx routen.