### PR TITLE
Ikke legg til  i navigasjonsstacken

### DIFF
--- a/app/src/routes/$id.index.tsx
+++ b/app/src/routes/$id.index.tsx
@@ -2,6 +2,10 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/$id/")({
   loader: () => {
-    throw redirect({ from: "/$id", to: "/$id/dine-opplysninger" });
+    throw redirect({
+      from: "/$id",
+      to: "/$id/dine-opplysninger",
+      replace: true,
+    });
   },
 });


### PR DESCRIPTION
Denne endringen gjør at man ikke får /$id i browserhistorikk-stacken, men heller bare /$id/dine-opplysninger