### PR TITLE
Oppsummerings-fikser

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -38,7 +38,6 @@
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-import": "2.29.1",
-        "eslint-plugin-lodash": "7.4.0",
         "eslint-plugin-prettier": "5.1.3",
         "eslint-plugin-react": "7.34.3",
         "eslint-plugin-simple-import-sort": "12.1.0",
@@ -3822,21 +3821,6 @@
         "node": "*"
       }
     },
-    "node_modules/eslint-plugin-lodash": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-7.4.0.tgz",
-      "integrity": "sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": ">=2"
-      }
-    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
@@ -5690,12 +5674,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
+++ b/app/src/features/skjema-moduler/PersonOgSelskapsInformasjonSeksjon.tsx
@@ -19,7 +19,11 @@ import {
   type InntektsmeldingSkjemaState,
   useInntektsmeldingSkjema,
 } from "~/features/InntektsmeldingSkjemaState";
-import { formatFødselsnummer, slåSammenTilFulltNavn } from "~/utils";
+import {
+  formatFødselsnummer,
+  formatYtelsesnavn,
+  slåSammenTilFulltNavn,
+} from "~/utils";
 
 import { InformasjonsseksjonMedKilde } from "../InformasjonsseksjonMedKilde";
 import { Fremgangsindikator } from "./Fremgangsindikator";
@@ -148,8 +152,8 @@ const Intro = ({ opplysninger }: IntroProps) => {
             {fulltNavn} ({formatFødselsnummer(person.fødselsnummer)})
           </strong>{" "}
           som jobber på <strong>{arbeidsgiver.organisasjonNavn}</strong> har
-          søkt om foreldrepenger. NAV trenger derfor informasjon om inntekten
-          til {fornavn}.
+          søkt om {formatYtelsesnavn(opplysninger.ytelse)}. NAV trenger derfor
+          informasjon om inntekten til {fornavn}.
         </BodyLong>
         <BodyLong>
           Vi har forhåndsutfylt skjema med opplysninger fra søknaden til{" "}

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -61,51 +61,30 @@ const IdDineOpplysningerRoute = IdDineOpplysningerImport.update({
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/$id': {
-      id: '/$id'
-      path: '/$id'
-      fullPath: '/$id'
       preLoaderRoute: typeof IdImport
       parentRoute: typeof rootRoute
     }
     '/$id/dine-opplysninger': {
-      id: '/$id/dine-opplysninger'
-      path: '/dine-opplysninger'
-      fullPath: '/$id/dine-opplysninger'
       preLoaderRoute: typeof IdDineOpplysningerImport
       parentRoute: typeof IdImport
     }
     '/$id/inntekt-og-refusjon': {
-      id: '/$id/inntekt-og-refusjon'
-      path: '/inntekt-og-refusjon'
-      fullPath: '/$id/inntekt-og-refusjon'
       preLoaderRoute: typeof IdInntektOgRefusjonImport
       parentRoute: typeof IdImport
     }
     '/$id/kvittering': {
-      id: '/$id/kvittering'
-      path: '/kvittering'
-      fullPath: '/$id/kvittering'
       preLoaderRoute: typeof IdKvitteringImport
       parentRoute: typeof IdImport
     }
     '/$id/oppsummering': {
-      id: '/$id/oppsummering'
-      path: '/oppsummering'
-      fullPath: '/$id/oppsummering'
       preLoaderRoute: typeof IdOppsummeringImport
       parentRoute: typeof IdImport
     }
     '/endre/$id': {
-      id: '/endre/$id'
-      path: '/endre/$id'
-      fullPath: '/endre/$id'
       preLoaderRoute: typeof EndreIdImport
       parentRoute: typeof rootRoute
     }
     '/$id/': {
-      id: '/$id/'
-      path: '/'
-      fullPath: '/$id/'
       preLoaderRoute: typeof IdIndexImport
       parentRoute: typeof IdImport
     }
@@ -114,62 +93,15 @@ declare module '@tanstack/react-router' {
 
 // Create and export the route tree
 
-export const routeTree = rootRoute.addChildren({
-  IdRoute: IdRoute.addChildren({
+export const routeTree = rootRoute.addChildren([
+  IdRoute.addChildren([
     IdDineOpplysningerRoute,
     IdInntektOgRefusjonRoute,
     IdKvitteringRoute,
     IdOppsummeringRoute,
     IdIndexRoute,
-  }),
+  ]),
   EndreIdRoute,
-})
+])
 
 /* prettier-ignore-end */
-
-/* ROUTE_MANIFEST_START
-{
-  "routes": {
-    "__root__": {
-      "filePath": "__root.tsx",
-      "children": [
-        "/$id",
-        "/endre/$id"
-      ]
-    },
-    "/$id": {
-      "filePath": "$id.tsx",
-      "children": [
-        "/$id/dine-opplysninger",
-        "/$id/inntekt-og-refusjon",
-        "/$id/kvittering",
-        "/$id/oppsummering",
-        "/$id/"
-      ]
-    },
-    "/$id/dine-opplysninger": {
-      "filePath": "$id.dine-opplysninger.tsx",
-      "parent": "/$id"
-    },
-    "/$id/inntekt-og-refusjon": {
-      "filePath": "$id.inntekt-og-refusjon.tsx",
-      "parent": "/$id"
-    },
-    "/$id/kvittering": {
-      "filePath": "$id.kvittering.tsx",
-      "parent": "/$id"
-    },
-    "/$id/oppsummering": {
-      "filePath": "$id.oppsummering.tsx",
-      "parent": "/$id"
-    },
-    "/endre/$id": {
-      "filePath": "endre.$id.tsx"
-    },
-    "/$id/": {
-      "filePath": "$id.index.tsx",
-      "parent": "/$id"
-    }
-  }
-}
-ROUTE_MANIFEST_END */

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -61,30 +61,51 @@ const IdDineOpplysningerRoute = IdDineOpplysningerImport.update({
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/$id': {
+      id: '/$id'
+      path: '/$id'
+      fullPath: '/$id'
       preLoaderRoute: typeof IdImport
       parentRoute: typeof rootRoute
     }
     '/$id/dine-opplysninger': {
+      id: '/$id/dine-opplysninger'
+      path: '/dine-opplysninger'
+      fullPath: '/$id/dine-opplysninger'
       preLoaderRoute: typeof IdDineOpplysningerImport
       parentRoute: typeof IdImport
     }
     '/$id/inntekt-og-refusjon': {
+      id: '/$id/inntekt-og-refusjon'
+      path: '/inntekt-og-refusjon'
+      fullPath: '/$id/inntekt-og-refusjon'
       preLoaderRoute: typeof IdInntektOgRefusjonImport
       parentRoute: typeof IdImport
     }
     '/$id/kvittering': {
+      id: '/$id/kvittering'
+      path: '/kvittering'
+      fullPath: '/$id/kvittering'
       preLoaderRoute: typeof IdKvitteringImport
       parentRoute: typeof IdImport
     }
     '/$id/oppsummering': {
+      id: '/$id/oppsummering'
+      path: '/oppsummering'
+      fullPath: '/$id/oppsummering'
       preLoaderRoute: typeof IdOppsummeringImport
       parentRoute: typeof IdImport
     }
     '/endre/$id': {
+      id: '/endre/$id'
+      path: '/endre/$id'
+      fullPath: '/endre/$id'
       preLoaderRoute: typeof EndreIdImport
       parentRoute: typeof rootRoute
     }
     '/$id/': {
+      id: '/$id/'
+      path: '/'
+      fullPath: '/$id/'
       preLoaderRoute: typeof IdIndexImport
       parentRoute: typeof IdImport
     }
@@ -93,15 +114,62 @@ declare module '@tanstack/react-router' {
 
 // Create and export the route tree
 
-export const routeTree = rootRoute.addChildren([
-  IdRoute.addChildren([
+export const routeTree = rootRoute.addChildren({
+  IdRoute: IdRoute.addChildren({
     IdDineOpplysningerRoute,
     IdInntektOgRefusjonRoute,
     IdKvitteringRoute,
     IdOppsummeringRoute,
     IdIndexRoute,
-  ]),
+  }),
   EndreIdRoute,
-])
+})
 
 /* prettier-ignore-end */
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/$id",
+        "/endre/$id"
+      ]
+    },
+    "/$id": {
+      "filePath": "$id.tsx",
+      "children": [
+        "/$id/dine-opplysninger",
+        "/$id/inntekt-og-refusjon",
+        "/$id/kvittering",
+        "/$id/oppsummering",
+        "/$id/"
+      ]
+    },
+    "/$id/dine-opplysninger": {
+      "filePath": "$id.dine-opplysninger.tsx",
+      "parent": "/$id"
+    },
+    "/$id/inntekt-og-refusjon": {
+      "filePath": "$id.inntekt-og-refusjon.tsx",
+      "parent": "/$id"
+    },
+    "/$id/kvittering": {
+      "filePath": "$id.kvittering.tsx",
+      "parent": "/$id"
+    },
+    "/$id/oppsummering": {
+      "filePath": "$id.oppsummering.tsx",
+      "parent": "/$id"
+    },
+    "/endre/$id": {
+      "filePath": "endre.$id.tsx"
+    },
+    "/$id/": {
+      "filePath": "$id.index.tsx",
+      "parent": "/$id"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -71,8 +71,12 @@ export function formatFødselsnummer(fødselsnummer: string) {
   return `${fødselsnummer.slice(0, 6)} ${fødselsnummer.slice(6)}`;
 }
 
-export function formatYtelsesnavn(ytelsesnavn: string) {
-  return ytelsesnavn.toLowerCase().replace("_", " ");
+export function formatYtelsesnavn(ytelsesnavn: string, storForbokstav = false) {
+  const formattert = ytelsesnavn.toLowerCase().replace("_", " ");
+  if (storForbokstav) {
+    return capitalize(formattert);
+  }
+  return formattert;
 }
 
 export function gjennomsnittInntekt(inntekter: MånedsinntektResponsDto[]) {

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -126,6 +126,49 @@ export const Oppsummering = () => {
                 {formatKroner(inntektsmeldingSkjemaState.inntekt)}
               </FormSummary.Value>
             </FormSummary.Answer>
+            {inntektsmeldingSkjemaState.inntektEndringsÅrsak && (
+              <>
+                <FormSummary.Answer>
+                  <FormSummary.Label>Korrigert månedslønn</FormSummary.Label>
+                  <FormSummary.Value>
+                    {formatKroner(
+                      inntektsmeldingSkjemaState.inntektEndringsÅrsak
+                        .korrigertInntekt,
+                    )}
+                  </FormSummary.Value>
+                </FormSummary.Answer>
+                <FormSummary.Answer>
+                  <FormSummary.Label>Korrigert grunnet</FormSummary.Label>
+                  <FormSummary.Value>
+                    {inntektsmeldingSkjemaState.inntektEndringsÅrsak.årsak}
+                  </FormSummary.Value>
+                </FormSummary.Answer>
+                {inntektsmeldingSkjemaState.inntektEndringsÅrsak.fom && (
+                  <FormSummary.Answer>
+                    <FormSummary.Label>Fra og med</FormSummary.Label>
+                    <FormSummary.Value>
+                      {formatDatoLang(
+                        new Date(
+                          inntektsmeldingSkjemaState.inntektEndringsÅrsak.fom,
+                        ),
+                      )}
+                    </FormSummary.Value>
+                  </FormSummary.Answer>
+                )}
+                {inntektsmeldingSkjemaState.inntektEndringsÅrsak.tom && (
+                  <FormSummary.Answer>
+                    <FormSummary.Label>Til og med</FormSummary.Label>
+                    <FormSummary.Value>
+                      {formatDatoLang(
+                        new Date(
+                          inntektsmeldingSkjemaState.inntektEndringsÅrsak.tom,
+                        ),
+                      )}
+                    </FormSummary.Value>
+                  </FormSummary.Answer>
+                )}
+              </>
+            )}
           </FormSummary.Answers>
         </FormSummary>
 

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -19,6 +19,7 @@ import type {
   SendInntektsmeldingRequestDto,
 } from "~/types/api-models.ts";
 import {
+  formatDatoKort,
   formatDatoLang,
   formatFødselsnummer,
   formatIsoDatostempel,
@@ -184,6 +185,28 @@ export const Oppsummering = () => {
               </FormSummary.Label>
               <FormSummary.Value>
                 {inntektsmeldingSkjemaState.misterNaturalytelser ? "Ja" : "Nei"}
+              </FormSummary.Value>
+            </FormSummary.Answer>
+            <FormSummary.Answer>
+              <FormSummary.Label>
+                Naturalytelser som faller bort
+              </FormSummary.Label>
+              <FormSummary.Value>
+                <FormSummary.Answers>
+                  {inntektsmeldingSkjemaState.naturalytelserSomMistes.map(
+                    (naturalytelse) => (
+                      <FormSummary.Answer key={naturalytelse.navn}>
+                        <FormSummary.Label>
+                          {formatYtelsesnavn(naturalytelse.navn, true)}
+                        </FormSummary.Label>
+                        <FormSummary.Value>
+                          Verdi {formatKroner(naturalytelse.beløp)} (fra og med{" "}
+                          {formatDatoKort(new Date(naturalytelse.fraOgMed))})
+                        </FormSummary.Value>
+                      </FormSummary.Answer>
+                    ),
+                  )}
+                </FormSummary.Answers>
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -27,39 +27,11 @@ import {
   slåSammenTilFulltNavn,
 } from "~/utils";
 
-const route = getRouteApi("/$id/oppsummering");
+const route = getRouteApi("/$id");
 
 export const Oppsummering = () => {
   const opplysninger = useLoaderData({ from: "/$id" });
   const { inntektsmeldingSkjemaState } = useInntektsmeldingSkjema();
-
-  const søknad = {
-    ytelseType: "Foreldrepenger",
-    oppstart: new Date("2024-01-01"),
-  };
-
-  const skjemadata = {
-    dineOpplysninger: {
-      arbeidsgiver: {
-        virksomhetsnavn: "Eksempelhuset AS",
-        orgnrForUnderenhet: "123 456 789",
-        kontaktperson: [{ navn: "Test Personesen", telefon: "815 49 300" }],
-      },
-      arbeidstaker: {
-        fornavn: "Ansa",
-        etternavn: "Tesen",
-        identitetsnummer: "01010123456",
-      },
-    },
-    inntektOgRefusjon: {
-      månedslønn: 45_000,
-      refusjon: {
-        refusjonBeløpPerMåned: 30_000,
-        endringIRefusjon: false,
-      },
-      naturalytelser: false,
-    },
-  };
 
   return (
     <section>
@@ -122,14 +94,14 @@ export const Oppsummering = () => {
         <FormSummary>
           <FormSummary.Header>
             <FormSummary.Heading level="3">
-              Første dag med {formatYtelsesnavn(søknad.ytelseType)}
+              Første dag med {formatYtelsesnavn(opplysninger.ytelse)}
             </FormSummary.Heading>
           </FormSummary.Header>
           <FormSummary.Answers>
             <FormSummary.Answer>
               <FormSummary.Label>Fra og med</FormSummary.Label>
               <FormSummary.Value>
-                {formatDatoLang(søknad.oppstart)}
+                {formatDatoLang(new Date(opplysninger.startdatoPermisjon))}
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>
@@ -147,10 +119,10 @@ export const Oppsummering = () => {
             <FormSummary.Answer>
               <FormSummary.Label>
                 Beregnet månedslønn basert på de tre siste, fulle månedene før{" "}
-                {formatYtelsesnavn(søknad.ytelseType)}
+                {formatYtelsesnavn(opplysninger.ytelse)}
               </FormSummary.Label>
               <FormSummary.Value>
-                {formatKroner(skjemadata.inntektOgRefusjon.månedslønn)}
+                {formatKroner(inntektsmeldingSkjemaState.inntekt)}
               </FormSummary.Value>
             </FormSummary.Answer>
           </FormSummary.Answers>
@@ -167,20 +139,19 @@ export const Oppsummering = () => {
           <FormSummary.Answers>
             <FormSummary.Answer>
               <FormSummary.Label>
-                Skal dere betale lønn til{" "}
-                {skjemadata.dineOpplysninger.arbeidstaker.fornavn} og ha
+                Skal dere betale lønn til {opplysninger.person.fornavn} og ha
                 refusjon fra NAV?
               </FormSummary.Label>
               <FormSummary.Value>
                 {inntektsmeldingSkjemaState.skalRefunderes ? "Ja" : "Nei"}
               </FormSummary.Value>
             </FormSummary.Answer>
-            {skjemadata.inntektOgRefusjon.refusjon && (
+            {inntektsmeldingSkjemaState.skalRefunderes && (
               <FormSummary.Answer>
                 <FormSummary.Label>Refusjonsbeløp per måned</FormSummary.Label>
                 <FormSummary.Value>
                   {formatKroner(
-                    skjemadata.inntektOgRefusjon.refusjon.refusjonBeløpPerMåned,
+                    inntektsmeldingSkjemaState.refusjonsbeløpPerMåned,
                   )}
                 </FormSummary.Value>
               </FormSummary.Answer>
@@ -188,8 +159,7 @@ export const Oppsummering = () => {
             <FormSummary.Answer>
               <FormSummary.Label>
                 Vil det være endringer i refusjon i løpet av perioden{" "}
-                {skjemadata.dineOpplysninger.arbeidstaker.fornavn} er i
-                permisjon?
+                {opplysninger.person.fornavn} er i permisjon?
               </FormSummary.Label>
               <FormSummary.Value>
                 {inntektsmeldingSkjemaState.endringIRefusjon ? "Ja" : "Nei"}
@@ -209,8 +179,8 @@ export const Oppsummering = () => {
           <FormSummary.Answers>
             <FormSummary.Answer>
               <FormSummary.Label>
-                Har {skjemadata.dineOpplysninger.arbeidstaker.fornavn}{" "}
-                naturalytelser som faller bort ved fraværet?
+                Har {opplysninger.person.fornavn} naturalytelser som faller bort
+                ved fraværet?
               </FormSummary.Label>
               <FormSummary.Value>
                 {inntektsmeldingSkjemaState.misterNaturalytelser ? "Ja" : "Nei"}

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -7,7 +7,6 @@ import {
   useLoaderData,
   useNavigate,
 } from "@tanstack/react-router";
-import { Fragment } from "react/jsx-runtime";
 
 import { sendInntektsmelding } from "~/api/mutations.ts";
 import type { OpplysningerDto } from "~/api/queries";
@@ -15,6 +14,7 @@ import type { InntektsmeldingSkjemaState } from "~/features/InntektsmeldingSkjem
 import { useInntektsmeldingSkjema } from "~/features/InntektsmeldingSkjemaState";
 import { Fremgangsindikator } from "~/features/skjema-moduler/Fremgangsindikator";
 import type {
+  ÅrsaksType,
   NaturalytelseRequestDto,
   RefusjonsperiodeRequestDto,
   SendInntektsmeldingRequestDto,
@@ -141,7 +141,9 @@ export const Oppsummering = () => {
                 <FormSummary.Answer>
                   <FormSummary.Label>Korrigert grunnet</FormSummary.Label>
                   <FormSummary.Value>
-                    {inntektsmeldingSkjemaState.inntektEndringsÅrsak.årsak}
+                    {formatInntektsendrignsGrunn(
+                      inntektsmeldingSkjemaState.inntektEndringsÅrsak.årsak,
+                    )}
                   </FormSummary.Value>
                 </FormSummary.Answer>
                 {inntektsmeldingSkjemaState.inntektEndringsÅrsak.fom && (
@@ -295,6 +297,20 @@ const formatterKontaktperson = (
     return "";
   }
   return `${kontaktperson.navn}, ${kontaktperson.telefonnummer}`;
+};
+
+const formatInntektsendrignsGrunn = (årsak: ÅrsaksType) => {
+  switch (årsak) {
+    case "Tariffendring": {
+      return "Tariffendring";
+    }
+    case "FeilInntekt": {
+      return "Varig feil inntekt";
+    }
+    default: {
+      return årsak;
+    }
+  }
 };
 
 type SendInnInntektsmeldingProps = {

--- a/app/src/views/oppsummering/Oppsummering.tsx
+++ b/app/src/views/oppsummering/Oppsummering.tsx
@@ -7,6 +7,7 @@ import {
   useLoaderData,
   useNavigate,
 } from "@tanstack/react-router";
+import { Fragment } from "react/jsx-runtime";
 
 import { sendInntektsmelding } from "~/api/mutations.ts";
 import type { OpplysningerDto } from "~/api/queries";
@@ -209,6 +210,30 @@ export const Oppsummering = () => {
                 {inntektsmeldingSkjemaState.endringIRefusjon ? "Ja" : "Nei"}
               </FormSummary.Value>
             </FormSummary.Answer>
+            {inntektsmeldingSkjemaState.endringIRefusjon && (
+              <FormSummary.Answer>
+                <FormSummary.Label>Endringer i refusjon</FormSummary.Label>
+                <FormSummary.Value>
+                  <FormSummary.Answers>
+                    {inntektsmeldingSkjemaState.refusjonsendringer.map(
+                      (endring) => (
+                        <FormSummary.Answer
+                          key={endring.fraOgMed + endring.beløp}
+                        >
+                          <FormSummary.Label>
+                            Refusjonsbeløp per måned
+                          </FormSummary.Label>
+                          <FormSummary.Value>
+                            {formatKroner(endring.beløp)} (fra og med{" "}
+                            {formatDatoLang(new Date(endring.fraOgMed))})
+                          </FormSummary.Value>
+                        </FormSummary.Answer>
+                      ),
+                    )}
+                  </FormSummary.Answers>
+                </FormSummary.Value>
+              </FormSummary.Answer>
+            )}
           </FormSummary.Answers>
         </FormSummary>
 
@@ -230,28 +255,31 @@ export const Oppsummering = () => {
                 {inntektsmeldingSkjemaState.misterNaturalytelser ? "Ja" : "Nei"}
               </FormSummary.Value>
             </FormSummary.Answer>
-            <FormSummary.Answer>
-              <FormSummary.Label>
-                Naturalytelser som faller bort
-              </FormSummary.Label>
-              <FormSummary.Value>
-                <FormSummary.Answers>
-                  {inntektsmeldingSkjemaState.naturalytelserSomMistes.map(
-                    (naturalytelse) => (
-                      <FormSummary.Answer key={naturalytelse.navn}>
-                        <FormSummary.Label>
-                          {formatYtelsesnavn(naturalytelse.navn, true)}
-                        </FormSummary.Label>
-                        <FormSummary.Value>
-                          Verdi {formatKroner(naturalytelse.beløp)} (fra og med{" "}
-                          {formatDatoKort(new Date(naturalytelse.fraOgMed))})
-                        </FormSummary.Value>
-                      </FormSummary.Answer>
-                    ),
-                  )}
-                </FormSummary.Answers>
-              </FormSummary.Value>
-            </FormSummary.Answer>
+            {inntektsmeldingSkjemaState.misterNaturalytelser && (
+              <FormSummary.Answer>
+                <FormSummary.Label>
+                  Naturalytelser som faller bort
+                </FormSummary.Label>
+                <FormSummary.Value>
+                  <FormSummary.Answers>
+                    {inntektsmeldingSkjemaState.naturalytelserSomMistes.map(
+                      (naturalytelse) => (
+                        <FormSummary.Answer key={naturalytelse.navn}>
+                          <FormSummary.Label>
+                            {formatYtelsesnavn(naturalytelse.navn, true)}
+                          </FormSummary.Label>
+                          <FormSummary.Value>
+                            Verdi {formatKroner(naturalytelse.beløp)} (fra og
+                            med{" "}
+                            {formatDatoKort(new Date(naturalytelse.fraOgMed))})
+                          </FormSummary.Value>
+                        </FormSummary.Answer>
+                      ),
+                    )}
+                  </FormSummary.Answers>
+                </FormSummary.Value>
+              </FormSummary.Answer>
+            )}
           </FormSummary.Answers>
         </FormSummary>
         <SendInnInntektsmelding opplysninger={opplysninger} />


### PR DESCRIPTION
Oppsumeringssiden hadde store mangler. Denne PRen endrer dette, slik at mesteparten i alle fall skal være på plass.

<img width="798" alt="image" src="https://github.com/navikt/ft-inntektsmelding-frontend/assets/1307267/35470b5f-2893-4992-9fa8-5ace801431bd">
<img width="746" alt="image" src="https://github.com/navikt/ft-inntektsmelding-frontend/assets/1307267/357d178d-a54a-4da2-b1ec-f2873df571c0">
<img width="749" alt="image" src="https://github.com/navikt/ft-inntektsmelding-frontend/assets/1307267/bd01243b-1e3f-483c-a2da-a199331470d7">
<img width="749" alt="image" src="https://github.com/navikt/ft-inntektsmelding-frontend/assets/1307267/2cb6e399-69f1-4c76-858d-4164ebb18e52">
