### PR TITLE
Legg til en error boundary for generelle tekniske feil

### DIFF
--- a/app/src/features/error-boundary/GenerellFeilside.tsx
+++ b/app/src/features/error-boundary/GenerellFeilside.tsx
@@ -1,0 +1,84 @@
+import {
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  HGrid,
+  Link,
+  List,
+  Page,
+  VStack,
+} from "@navikt/ds-react";
+import { PageBlock } from "@navikt/ds-react/Page";
+
+export const GenerellFeilside = () => {
+  return (
+    <Page>
+      <PageBlock as="main" gutters width="xl">
+        <Box paddingBlock="20 8">
+          <HGrid columns="minmax(auto,600px)" data-aksel-template="500-v2">
+            <VStack gap="16">
+              <VStack align="start" gap="12">
+                <div>
+                  <BodyShort size="small" textColor="subtle">
+                    Statuskode 500
+                  </BodyShort>
+                  <Heading level="1" size="large" spacing>
+                    Beklager, noe gikk galt.
+                  </Heading>
+                  <BodyShort spacing>
+                    En teknisk feil på våre servere gjør at siden er
+                    utilgjengelig. Dette skyldes ikke noe du gjorde.
+                  </BodyShort>
+                  <BodyShort>Du kan prøve å</BodyShort>
+                  <List>
+                    <List.Item>
+                      vente noen minutter og{" "}
+                      <Link href="#" onClick={() => location.reload()}>
+                        laste siden på nytt
+                      </Link>
+                    </List.Item>
+                    <List.Item>
+                      {window.history.length > 1 && (
+                        <Link href="#" onClick={() => history.back()}>
+                          gå tilbake til forrige side
+                        </Link>
+                      )}
+                    </List.Item>
+                  </List>
+                  <BodyShort>
+                    Hvis problemet vedvarer, kan du{" "}
+                    <Link href="https://nav.no/kontaktoss" target="_blank">
+                      kontakte oss (åpnes i ny fane)
+                    </Link>
+                    .
+                  </BodyShort>
+                </div>
+
+                <Button as="a" href="/min-side-arbeidsgiver">
+                  Gå til Min side - arbeidsgiver
+                </Button>
+              </VStack>
+
+              <div>
+                <Heading level="1" size="large" spacing>
+                  Something went wrong
+                </Heading>
+                <BodyShort spacing>
+                  This was caused by a technical fault on our servers. Please
+                  refresh this page or try again in a few minutes.{" "}
+                </BodyShort>
+                <BodyShort>
+                  <Link href="https://www.nav.no/kontaktoss/en" target="_blank">
+                    Contact us (opens in new tab)
+                  </Link>{" "}
+                  if the problem persists.
+                </BodyShort>
+              </div>
+            </VStack>
+          </HGrid>
+        </Box>
+      </PageBlock>
+    </Page>
+  );
+};

--- a/app/src/features/error-boundary/GenerellFeilside.tsx
+++ b/app/src/features/error-boundary/GenerellFeilside.tsx
@@ -20,9 +20,6 @@ export const GenerellFeilside = () => {
             <VStack gap="16">
               <VStack align="start" gap="12">
                 <div>
-                  <BodyShort size="small" textColor="subtle">
-                    Statuskode 500
-                  </BodyShort>
                   <Heading level="1" size="large" spacing>
                     Beklager, noe gikk galt.
                   </Heading>

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 import React from "react";
 
 import { hentGrunnbeløpOptions } from "~/api/queries.ts";
+import { GenerellFeilside } from "~/features/error-boundary/GenerellFeilside";
 import { VisHjelpeteksterStateProvider } from "~/features/Hjelpetekst.tsx";
 
 const TanStackRouterDevtools = import.meta.env.PROD
@@ -25,6 +26,7 @@ export const Route = createRootRouteWithContext<{
     // Bruker prefetch for å ikke vente på dette nettverkskallet, men gjøre det klar i cache så fort som mulig
     context.queryClient.prefetchQuery(hentGrunnbeløpOptions());
   },
+  errorComponent: GenerellFeilside,
 
   component: () => {
     return (


### PR DESCRIPTION
Om man får en feil, er det fint at vi viser en faktisk feilside, og ikke bare en hvit side uten noen kontekst.

Denne PRen legger til NAVs standard malverk for slike sider

<img width="1487" alt="image" src="https://github.com/user-attachments/assets/26670615-6288-46c0-861a-f29d957e3097">
