### PR TITLE
Legg til oppsett for Playwright, mocking, og en enkel test

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -20,3 +20,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+test-results
+playwright-report

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,6 +26,7 @@
         "@eslint/eslintrc": "3.1.0",
         "@eslint/js": "9.9.1",
         "@navikt/aksel-stylelint": "6.16.2",
+        "@playwright/test": "^1.42.1",
         "@tanstack/eslint-plugin-query": "5.52.0",
         "@tanstack/react-query-devtools": "5.52.2",
         "@tanstack/router-devtools": "1.51.2",
@@ -1316,6 +1317,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
+      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.47.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5691,6 +5708,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
+      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.47.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
+      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,8 @@
     "build": "tsc && vite build",
     "build:fp": "tsc && vite build --base=/fp-im-dialog",
     "build:k9": "tsc && vite build --base=/k9-im-dialog",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "check:types": "tsc --noemit",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
@@ -58,6 +60,7 @@
     "tailwindcss": "3.4.10",
     "typescript": "5.5.4",
     "typescript-eslint": "8.3.0",
-    "vite": "5.4.2"
+    "vite": "5.4.2",
+    "@playwright/test": "^1.42.1"
   }
 }

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev:fp",
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/app/tests/README.md
+++ b/app/tests/README.md
@@ -1,0 +1,31 @@
+# Ende-til-ende tester
+
+Denne mappen inneholder tester som kjører i Playwright.
+
+## Playwright?
+
+Playwright er et verktøy for å lage og kjøre ende-til-ende tester for webapplikasjoner. Vi bruker dette til å teste vår frontend.
+
+Du kan lære mer om playwright [her](https://playwright.dev/).
+
+For å kjøre tester lokalt, må du først ha installert Playwright. Det gjør du med:
+
+```bash
+npx playwright install
+```
+
+Når du har installert playwright, kan du kjøre tester med:
+
+```bash
+npm run test:e2e
+```
+
+For å kjøre tester med et brukergrensesnitt, kjør:
+
+```bash
+npm run test:e2e:ui
+```
+
+## Mocking av data
+
+Vi har alle API-mocker i egne filer per endepunkt i `tests/mocks`, som du kan velge å bruke i testene dine. Du kan se hvordan man mocker i [dokumentasjonen til Playwright](https://playwright.dev/docs/mock).

--- a/app/tests/e2e/dine-opplysninger.spec.tsx
+++ b/app/tests/e2e/dine-opplysninger.spec.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import { grunnbeløpResponse } from "tests/mocks/grunnbeløp";
+import { enkeltGrunnlagResponse } from "tests/mocks/grunnlag";
+
+test("should load inntektsmelding page", async ({ page }) => {
+  await page.route(
+    "**/*/imdialog/grunnlag?foresporselUuid=1",
+    async (route) => {
+      await route.fulfill({ json: enkeltGrunnlagResponse });
+    },
+  );
+  await page.route("https://g.nav.no/api/v1/grunnbel%C3%B8p", async (route) => {
+    await route.fulfill({ json: grunnbeløpResponse });
+  });
+  await page.route(
+    "**/*/imdialog/inntektsmeldinger?foresporselUuid=1",
+    async (route) => {
+      await route.fulfill({ json: [] });
+    },
+  );
+
+  await page.goto("/fp-im-dialog/1/dine-opplysninger");
+
+  await expect(
+    page.getByText("Ola Normann Hansen", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Ola Normann Hansen (123456 78901)"),
+  ).toBeVisible();
+
+  await expect(page.getByLabel("Navn")).toBeVisible();
+  await expect(page.getByLabel("Navn")).toHaveValue("Kari Normann Hansen");
+
+  await expect(page.getByLabel("Telefon")).toBeVisible();
+  await expect(page.getByLabel("Telefon")).toHaveValue("12345678");
+});

--- a/app/tests/mocks/grunnbeløp.ts
+++ b/app/tests/mocks/grunnbeløp.ts
@@ -1,0 +1,8 @@
+export const grunnbeløpResponse = {
+  dato: "2024-05-01",
+  grunnbeløp: 118_620,
+  grunnbeløpPerMåned: 9885,
+  gjennomsnittPerÅr: 116_207,
+  omregningsfaktor: 1.0473,
+  virkningstidspunktForMinsteinntekt: "2024-05-01",
+};

--- a/app/tests/mocks/grunnlag.ts
+++ b/app/tests/mocks/grunnlag.ts
@@ -1,0 +1,35 @@
+export const enkeltGrunnlagResponse = {
+  person: {
+    aktørId: "1234567890123",
+    fødselsnummer: "12345678901",
+    fornavn: "Ola",
+    mellomnavn: "Normann",
+    etternavn: "Hansen",
+  },
+  innsender: {
+    fornavn: "Kari",
+    mellomnavn: "Normann",
+    etternavn: "Hansen",
+    telefon: "12345678",
+  },
+  arbeidsgiver: {
+    organisasjonNavn: "Bedrift AS",
+    organisasjonNummer: "123456789",
+  },
+  inntekter: [
+    {
+      fom: "2023-01-01",
+      tom: "2023-12-31",
+      beløp: 500_000,
+      arbeidsgiverIdent: "123456789",
+    },
+    {
+      fom: "2022-01-01",
+      tom: "2022-12-31",
+      beløp: 480_000,
+      arbeidsgiverIdent: "123456789",
+    },
+  ],
+  startdatoPermisjon: "2024-03-01",
+  ytelse: "FORELDREPENGER",
+} as const;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -26,6 +26,6 @@
     },
     "types": ["vite/client"],
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }],
 }


### PR DESCRIPTION
Denne PRen legger til støtte for å skrive ende-til-ende-tester med Playwright.

Man legger til testfilene i `tests/e2e`-mappa, man legger til mock data i `tests/mocks` mappa, og ellers er det bare tut og kjør. Skrev også en enkel test av dine-opplysninger.

Det er nok endel forbedringer vi kan gjøre her, som å sette opp noen standardmocks for kall alle tester må mocke (grunnbeløp for eksempel), samt å forbedre dokumentasjonen. Men tenker vi kan ta mye av det underveis. Vi har også en haug med tester å skrive, selvfølgelig.