### PR TITLE
Nytt refusjons design

### DIFF
--- a/app/src/api/queries.ts
+++ b/app/src/api/queries.ts
@@ -80,7 +80,6 @@ export function mapInntektsmeldingResponseTilValidState(
         fom: periode.fom,
       }),
     ),
-    endringIRefusjon: (inntektsmelding.refusjonsendringer ?? []).length > 0,
     naturalytelserSomMistes:
       inntektsmelding.bortfaltNaturalytelsePerioder?.map((periode) => ({
         navn: periode.naturalytelsetype,
@@ -91,7 +90,13 @@ export function mapInntektsmeldingResponseTilValidState(
       })) ?? [],
     inntektEndringsÅrsak: undefined, // TODO: Send inn når BE har støtte for det
     inntekt: inntektsmelding.inntekt,
-    skalRefunderes: Boolean(inntektsmelding.refusjon),
+    // TODO: denne ble stygg
+    skalRefunderes:
+      (inntektsmelding.refusjonsendringer ?? []).length > 0
+        ? "JA_VARIERENDE_REFUSJON"
+        : inntektsmelding.refusjon
+          ? "JA_LIK_REFUSJON"
+          : "NEI",
     misterNaturalytelser:
       (inntektsmelding.bortfaltNaturalytelsePerioder?.length ?? 0) > 0,
     opprettetTidspunkt: inntektsmelding.opprettetTidspunkt,

--- a/app/src/features/InntektsmeldingSkjemaState.tsx
+++ b/app/src/features/InntektsmeldingSkjemaState.tsx
@@ -27,9 +27,14 @@ export const InntektsmeldingSkjemaStateSchema = z.object({
       tom: z.string().optional(),
     })
     .optional(),
-  skalRefunderes: z.boolean().optional(),
+  skalRefunderes: z
+    .union([
+      z.literal("JA_LIK_REFUSJON"),
+      z.literal("JA_VARIERENDE_REFUSJON"),
+      z.literal("NEI"),
+    ])
+    .optional(),
   refusjonsbeløpPerMåned: beløpSchema,
-  endringIRefusjon: z.boolean().optional(),
   refusjonsendringer: z.array(
     z.object({
       fom: z.string().optional(),
@@ -62,9 +67,12 @@ export const InntektsmeldingSkjemaStateSchemaValidated = z.object({
       tom: z.string().optional(),
     })
     .optional(),
-  skalRefunderes: z.boolean(),
+  skalRefunderes: z.union([
+    z.literal("JA_LIK_REFUSJON"),
+    z.literal("JA_VARIERENDE_REFUSJON"),
+    z.literal("NEI"),
+  ]),
   refusjonsbeløpPerMåned: beløpSchema,
-  endringIRefusjon: z.boolean().optional(),
   refusjonsendringer: z.array(
     z.object({
       fom: z.string(),

--- a/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
+++ b/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
@@ -14,7 +14,6 @@ import {
   VStack,
 } from "@navikt/ds-react";
 import { useQuery } from "@tanstack/react-query";
-import clsx from "clsx";
 import { Fragment, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
@@ -23,6 +22,13 @@ import { HjelpetekstReadMore } from "~/features/Hjelpetekst.tsx";
 import { DatePickerWrapped } from "~/features/react-hook-form-wrappers/DatePickerWrapped.tsx";
 import type { InntektOgRefusjonForm } from "~/routes/$id.inntekt-og-refusjon.tsx";
 import { formatKroner } from "~/utils.ts";
+
+export const REFUSJON_RADIO_VALG = {
+  JA_LIK_REFUSJON: "Ja, likt beløp i hele perioden",
+  JA_VARIERENDE_REFUSJON:
+    "Ja, men kun deler av perioden eller varierende beløp",
+  NEI: "Nei",
+} satisfies Record<InntektOgRefusjonForm["skalRefunderes"], string>;
 
 export function UtbetalingOgRefusjon() {
   const { register, formState, watch } =
@@ -60,13 +66,13 @@ export function UtbetalingOgRefusjon() {
         name={name}
       >
         <Radio value="JA_LIK_REFUSJON" {...radioGroupProps}>
-          Ja, likt beløp i hele perioden
+          {REFUSJON_RADIO_VALG["JA_LIK_REFUSJON"]}
         </Radio>
         <Radio value="JA_VARIERENDE_REFUSJON" {...radioGroupProps}>
-          Ja, men kun deler av perioden eller varierende beløp
+          {REFUSJON_RADIO_VALG["JA_VARIERENDE_REFUSJON"]}
         </Radio>
         <Radio value="NEI" {...radioGroupProps}>
-          Nei
+          {REFUSJON_RADIO_VALG["NEI"]}
         </Radio>
       </RadioGroup>
       {skalRefunderes === "JA_LIK_REFUSJON" ? <LikRefusjon /> : undefined}
@@ -105,173 +111,92 @@ function LikRefusjon() {
   const refusjonsbeløpPerMåned = watch("refusjonsbeløpPerMåned");
 
   return (
-    <div>
-      {skalEndreBeløp ? (
-        <Stack gap="4">
-          <HStack gap="4">
-            <TextField
-              {...register("refusjonsbeløpPerMåned")}
-              autoFocus
-              label="Refusjonsbeløp per måned"
-            />
+    <>
+      <div>
+        {skalEndreBeløp ? (
+          <Stack gap="4">
+            <HStack gap="4">
+              <TextField
+                {...register("refusjonsbeløpPerMåned")}
+                autoFocus
+                label="Refusjonsbeløp per måned"
+              />
+              <Button
+                className="mt-8"
+                onClick={() => setSkalEndreBeløp(false)}
+                size="small"
+                variant="tertiary"
+              >
+                Tilbakestill
+              </Button>
+            </HStack>
+            <Over6GAlert />
+          </Stack>
+        ) : (
+          <>
+            <Label>Refusjonsbeløp per måned</Label>
+            <BodyLong className="mb-2" size="medium">
+              {formatKroner(refusjonsbeløpPerMåned)}
+            </BodyLong>
             <Button
-              className="mt-8"
-              onClick={() => setSkalEndreBeløp(false)}
+              className="w-fit"
+              icon={<PencilIcon />}
+              iconPosition="left"
+              onClick={() => setSkalEndreBeløp(true)} //TODO: proper reset
               size="small"
-              variant="tertiary"
+              variant="secondary"
             >
-              Tilbakestill
+              Endre refusjonsbeløp
             </Button>
-          </HStack>
-          <Over6GAlert />
-        </Stack>
-      ) : (
-        <>
-          <Label>Refusjonsbeløp per måned</Label>
-          <BodyLong className="mb-2" size="medium">
-            {formatKroner(refusjonsbeløpPerMåned)}
-          </BodyLong>
-          <Button
-            className="w-fit"
-            icon={<PencilIcon />}
-            iconPosition="left"
-            onClick={() => setSkalEndreBeløp(true)} //TODO: proper reset
-            size="small"
-            variant="secondary"
-          >
-            Endre refusjonsbeløp
-          </Button>
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+      <DelvisFraværHjelpetekst />
+    </>
   );
 }
 
 function VarierendeRefusjon() {
   return (
-    <VStack>
-      <Heading level="2" size="small">
-        Refusjonsbeløp dere krever per måned
-      </Heading>
-      <BodyShort size="medium" spacing textColor="subtle">
-        Skal dere slutte å forskuttere lønn underveis i perioden, skriver du 0,-
-        i refusjon fra datoen dere ikke lengre forskutterer lønn.
-      </BodyShort>
-      <RefusjonsPerioder />
-    </VStack>
+    <>
+      <VStack>
+        <Heading level="2" size="small">
+          Refusjonsbeløp dere krever per måned
+        </Heading>
+        <BodyShort size="medium" spacing textColor="subtle">
+          Skal dere slutte å forskuttere lønn underveis i perioden, skriver du
+          0,- i refusjon fra datoen dere ikke lengre forskutterer lønn.
+        </BodyShort>
+        <RefusjonsPerioder />
+      </VStack>
+      <VStack gap="2">
+        <DelvisFraværHjelpetekst />
+        <HjelpetekstReadMore header="Hvilke endringer må du informere NAV om?">
+          <Stack gap="2">
+            <BodyLong>
+              Her skal du registrere endringer som påvirker refusjonen fra NAV.
+            </BodyLong>
+            <BodyLong>
+              Dette kan være på grunn av endret stillingsprosent som gjør at
+              lønnen dere forskutterer endrer seg i perioden
+            </BodyLong>
+            <BodyLong>
+              Hvis dere skal slutte å forskuttere lønn i perioden, registrerer
+              du det som en endring her. Dette kan være fordi arbeidsforholdet
+              opphører, eller fordi dere kun forskutterer en begrenset periode.
+              Du skriver da 0,- i refusjon fra den datoen dere ikke lengre
+              forskutterer lønn.
+            </BodyLong>
+            <BodyLong>
+              Du trenger ikke å informere om endringer fordi den ansatte jobber
+              mer eller mindre i en periode.
+            </BodyLong>
+          </Stack>
+        </HjelpetekstReadMore>
+      </VStack>
+    </>
   );
 }
-//
-// function Refusjon({ opplysninger }: UtbetalingOgRefusjonProps) {
-//   const { register, formState, watch } =
-//     useFormContext<InntektOgRefusjonForm>();
-//   const { name, ...radioGroupProps } = register("endringIRefusjon", {
-//     required: "Du må svare på dette spørsmålet",
-//     shouldUnregister: true,
-//   });
-//
-//   const [skalEndreBeløp, setSkalEndreBeløp] = useState(false);
-//
-//   const endringIRefusjon = watch("endringIRefusjon");
-//   const refusjonsbeløpPerMåned = watch("refusjonsbeløpPerMåned");
-//   const GRUNNBELØP = useQuery(hentGrunnbeløpOptions()).data;
-//   const refusjonsbeløpPerMånedSomNummer = Number(refusjonsbeløpPerMåned);
-//   const erRefusjonOver6G =
-//     !Number.isNaN(refusjonsbeløpPerMånedSomNummer) &&
-//     refusjonsbeløpPerMånedSomNummer > 6 * GRUNNBELØP;
-//
-//   return (
-//     <div className="bg-bg-subtle p-4 flex flex-col gap-4 rounded-md">
-//       {skalEndreBeløp ? (
-//         <Stack gap="4">
-//           <HStack gap="4">
-//             <TextField
-//               {...register("refusjonsbeløpPerMåned")}
-//               autoFocus
-//               label="Refusjonsbeløp per måned"
-//             />
-//             <Button
-//               className="mt-8"
-//               onClick={() => setSkalEndreBeløp(false)}
-//               variant="tertiary"
-//             >
-//               Tilbakestill
-//             </Button>
-//           </HStack>
-//           {erRefusjonOver6G && (
-//             <Alert variant="info">
-//               NAV utbetaler opptil 6G av årslønnen. Du skal likevel føre opp den
-//               lønnen dere utbetaler til den ansatte i sin helhet.
-//             </Alert>
-//           )}
-//         </Stack>
-//       ) : (
-//         <>
-//           <span>Refusjonsbeløp per måned</span>
-//           <Heading level="3" size="medium">
-//             {formatKroner(refusjonsbeløpPerMåned)}
-//           </Heading>
-//           <Button
-//             className="w-fit"
-//             icon={<PencilIcon />}
-//             iconPosition="left"
-//             onClick={() => setSkalEndreBeløp(true)}
-//             size="small"
-//             variant="secondary"
-//           >
-//             Endre refusjonsbeløp
-//           </Button>
-//         </>
-//       )}
-//       <HjelpetekstReadMore header="Har den ansatte delvis fravær i perioden?">
-//         <BodyLong>
-//           Hvis den ansatte skal kombinere stønad fra NAV med arbeid, vil NAV
-//           redusere utbetalingen ut fra opplysningene fra den ansatte. Du oppgir
-//           derfor den månedslønnen dere utbetaler til den ansatte, uavhengig av
-//           hvor mye den ansatte skal jobbe.
-//         </BodyLong>
-//       </HjelpetekstReadMore>
-//       <RadioGroup
-//         error={formState.errors.endringIRefusjon?.message}
-//         legend="Betaler dere lønn under fraværet og krever refusjon?"
-//         name={name}
-//       >
-//         <Radio value="JA_LIK_REFUSJON" {...radioGroupProps}>
-//           Ja, likt beløp i hele perioden
-//         </Radio>
-//         <Radio value="JA_VARIERENDE_REFUSJON" {...radioGroupProps}>
-//           Ja, men kun deler av perioden eller varierende beløp
-//         </Radio>
-//         <Radio value="nei" {...radioGroupProps}>
-//           Nei
-//         </Radio>
-//       </RadioGroup>
-//       <HjelpetekstReadMore header="Hvilke endringer må du informere NAV om?">
-//         <Stack gap="2">
-//           <BodyLong>
-//             Her skal du registrere endringer som påvirker refusjonen fra NAV.
-//           </BodyLong>
-//           <BodyLong>
-//             Dette kan være på grunn av endret stillingsprosent som gjør at
-//             lønnen dere forskutterer endrer seg i perioden
-//           </BodyLong>
-//           <BodyLong>
-//             Hvis dere skal slutte å forskuttere lønn i perioden, registrerer du
-//             det som en endring her. Dette kan være fordi arbeidsforholdet
-//             opphører, eller fordi dere kun forskutterer en begrenset periode. Du
-//             skriver da 0,- i refusjon fra den datoen dere ikke lengre
-//             forskutterer lønn.
-//           </BodyLong>
-//           <BodyLong>
-//             Du trenger ikke å informere om endringer fordi den ansatte jobber
-//             mer eller mindre i en periode.
-//           </BodyLong>
-//         </Stack>
-//       </HjelpetekstReadMore>
-//       {endringIRefusjon === "ja" ? <RefusjonsPerioder /> : undefined}
-//     </div>
-//   );
-// }
 
 export const ENDRING_I_REFUSJON_TEMPLATE = {
   fom: undefined,
@@ -291,25 +216,27 @@ function RefusjonsPerioder() {
       {fields.map((field, index) => (
         <Fragment key={field.id}>
           <DatePickerWrapped
-            // hideLabel={index > 0}
             label="Fra og med"
             name={`refusjonsendringer.${index}.fom` as const}
             readOnly={index === 0}
             rules={{ required: "Må oppgis" }}
           />
           <TextField
-            {...register(`refusjonsendringer.${index}.beløp` as const)}
+            {...register(`refusjonsendringer.${index}.beløp` as const, {
+              valueAsNumber: true,
+              validate: (value) => Number(value) >= 0 || "asdsa",
+              required: "Må oppgis",
+            })}
             error={
               formState.errors?.refusjonsendringer?.[index]?.beløp?.message
             }
-            // hideLabel={index > 0}
             inputMode="numeric"
-            label={<span>Endret refusjon per måned</span>}
+            label="Refusjonsbeløp per måned"
             size="medium"
           />
           <Button
             aria-label="fjern refusjonsendring"
-            className={clsx({ "mt-8": index === 0 })}
+            className="mt-8"
             disabled={index === 0}
             icon={<TrashIcon />}
             onClick={() => remove(index)}
@@ -329,5 +256,18 @@ function RefusjonsPerioder() {
         Legg til ny periode
       </Button>
     </div>
+  );
+}
+
+function DelvisFraværHjelpetekst() {
+  return (
+    <HjelpetekstReadMore header="Har den ansatte delvis fravær i perioden?">
+      <BodyLong>
+        Hvis den ansatte skal kombinere stønad fra NAV med arbeid, vil NAV
+        redusere utbetalingen ut fra opplysningene fra den ansatte. Du oppgir
+        derfor den månedslønnen dere utbetaler til den ansatte, uavhengig av
+        hvor mye den ansatte skal jobbe.
+      </BodyLong>
+    </HjelpetekstReadMore>
   );
 }

--- a/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
+++ b/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
@@ -105,11 +105,11 @@ function Over6GAlert() {
 }
 
 function LikRefusjon() {
-  const { register, watch } = useFormContext<InntektOgRefusjonForm>();
+  const { register, watch, resetField } =
+    useFormContext<InntektOgRefusjonForm>();
   const [skalEndreBeløp, setSkalEndreBeløp] = useState(false);
 
   const refusjonsbeløpPerMåned = watch("refusjonsbeløpPerMåned");
-
   return (
     <>
       <div>
@@ -117,13 +117,16 @@ function LikRefusjon() {
           <Stack gap="4">
             <HStack gap="4">
               <TextField
-                {...register("refusjonsbeløpPerMåned")}
+                {...register("refusjonsbeløpPerMåned", {})}
                 autoFocus
                 label="Refusjonsbeløp per måned"
               />
               <Button
                 className="mt-8"
-                onClick={() => setSkalEndreBeløp(false)}
+                onClick={() => {
+                  resetField("refusjonsbeløpPerMåned");
+                  setSkalEndreBeløp(false);
+                }}
                 size="small"
                 variant="tertiary"
               >
@@ -142,7 +145,9 @@ function LikRefusjon() {
               className="w-fit"
               icon={<PencilIcon />}
               iconPosition="left"
-              onClick={() => setSkalEndreBeløp(true)} //TODO: proper reset
+              onClick={() => {
+                setSkalEndreBeløp(true);
+              }}
               size="small"
               variant="secondary"
             >

--- a/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
+++ b/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
@@ -2,7 +2,6 @@ import { PencilIcon, PlusIcon, TrashIcon } from "@navikt/aksel-icons";
 import {
   Alert,
   BodyLong,
-  BodyShort,
   Button,
   Heading,
   HStack,
@@ -168,10 +167,10 @@ function VarierendeRefusjon() {
         <Heading level="2" size="small">
           Refusjonsbeløp dere krever per måned
         </Heading>
-        <BodyShort size="medium" spacing textColor="subtle">
-          Skal dere slutte å forskuttere lønn underveis i perioden, skriver du
-          0,- i refusjon fra datoen dere ikke lengre forskutterer lønn.
-        </BodyShort>
+        <Alert className="mb-4" inline variant="info">
+          Skal dere slutte å forskuttere lønn i perioden, skriver du 0,- i
+          refusjonsbeløp fra den datoen dere ikke lengre forskutterer lønn.
+        </Alert>
         <RefusjonsPerioder />
       </VStack>
       <VStack gap="2">
@@ -242,11 +241,13 @@ function RefusjonsPerioder() {
           <Button
             aria-label="fjern refusjonsendring"
             className="mt-8"
-            disabled={index === 0}
+            disabled={index < 2}
             icon={<TrashIcon />}
             onClick={() => remove(index)}
             variant="tertiary"
-          />
+          >
+            Slett
+          </Button>
         </Fragment>
       ))}
       <Button

--- a/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
+++ b/app/src/features/skjema-moduler/UtbetalingOgRefusjon.tsx
@@ -2,6 +2,7 @@ import { PencilIcon, PlusIcon, TrashIcon } from "@navikt/aksel-icons";
 import {
   Alert,
   BodyLong,
+  BodyShort,
   Button,
   Heading,
   HStack,
@@ -21,15 +22,9 @@ import { hentGrunnbeløpOptions } from "~/api/queries.ts";
 import { HjelpetekstReadMore } from "~/features/Hjelpetekst.tsx";
 import { DatePickerWrapped } from "~/features/react-hook-form-wrappers/DatePickerWrapped.tsx";
 import type { InntektOgRefusjonForm } from "~/routes/$id.inntekt-og-refusjon.tsx";
-import type { OpplysningerDto } from "~/types/api-models.ts";
 import { formatKroner } from "~/utils.ts";
 
-type UtbetalingOgRefusjonProps = {
-  opplysninger: OpplysningerDto;
-};
-export function UtbetalingOgRefusjon({
-  opplysninger,
-}: UtbetalingOgRefusjonProps) {
+export function UtbetalingOgRefusjon() {
   const { register, formState, watch } =
     useFormContext<InntektOgRefusjonForm>();
   const { name, ...radioGroupProps } = register("skalRefunderes", {
@@ -76,7 +71,7 @@ export function UtbetalingOgRefusjon({
       </RadioGroup>
       {skalRefunderes === "JA_LIK_REFUSJON" ? <LikRefusjon /> : undefined}
       {skalRefunderes === "JA_VARIERENDE_REFUSJON" ? (
-        <Refusjon opplysninger={opplysninger} />
+        <VarierendeRefusjon />
       ) : undefined}
     </VStack>
   );
@@ -152,116 +147,131 @@ function LikRefusjon() {
   );
 }
 
-function Refusjon({ opplysninger }: UtbetalingOgRefusjonProps) {
-  const { register, formState, watch } =
-    useFormContext<InntektOgRefusjonForm>();
-  const { name, ...radioGroupProps } = register("endringIRefusjon", {
-    required: "Du må svare på dette spørsmålet",
-    shouldUnregister: true,
-  });
-
-  const [skalEndreBeløp, setSkalEndreBeløp] = useState(false);
-
-  const endringIRefusjon = watch("endringIRefusjon");
-  const refusjonsbeløpPerMåned = watch("refusjonsbeløpPerMåned");
-  const GRUNNBELØP = useQuery(hentGrunnbeløpOptions()).data;
-  const refusjonsbeløpPerMånedSomNummer = Number(refusjonsbeløpPerMåned);
-  const erRefusjonOver6G =
-    !Number.isNaN(refusjonsbeløpPerMånedSomNummer) &&
-    refusjonsbeløpPerMånedSomNummer > 6 * GRUNNBELØP;
-
+function VarierendeRefusjon() {
   return (
-    <div className="bg-bg-subtle p-4 flex flex-col gap-4 rounded-md">
-      {skalEndreBeløp ? (
-        <Stack gap="4">
-          <HStack gap="4">
-            <TextField
-              {...register("refusjonsbeløpPerMåned")}
-              autoFocus
-              label="Refusjonsbeløp per måned"
-            />
-            <Button
-              className="mt-8"
-              onClick={() => setSkalEndreBeløp(false)}
-              variant="tertiary"
-            >
-              Tilbakestill
-            </Button>
-          </HStack>
-          {erRefusjonOver6G && (
-            <Alert variant="info">
-              NAV utbetaler opptil 6G av årslønnen. Du skal likevel føre opp den
-              lønnen dere utbetaler til den ansatte i sin helhet.
-            </Alert>
-          )}
-        </Stack>
-      ) : (
-        <>
-          <span>Refusjonsbeløp per måned</span>
-          <Heading level="3" size="medium">
-            {formatKroner(refusjonsbeløpPerMåned)}
-          </Heading>
-          <Button
-            className="w-fit"
-            icon={<PencilIcon />}
-            iconPosition="left"
-            onClick={() => setSkalEndreBeløp(true)}
-            size="small"
-            variant="secondary"
-          >
-            Endre refusjonsbeløp
-          </Button>
-        </>
-      )}
-      <HjelpetekstReadMore header="Har den ansatte delvis fravær i perioden?">
-        <BodyLong>
-          Hvis den ansatte skal kombinere stønad fra NAV med arbeid, vil NAV
-          redusere utbetalingen ut fra opplysningene fra den ansatte. Du oppgir
-          derfor den månedslønnen dere utbetaler til den ansatte, uavhengig av
-          hvor mye den ansatte skal jobbe.
-        </BodyLong>
-      </HjelpetekstReadMore>
-      <RadioGroup
-        error={formState.errors.endringIRefusjon?.message}
-        legend="Betaler dere lønn under fraværet og krever refusjon?"
-        name={name}
-      >
-        <Radio value="JA_LIK_REFUSJON" {...radioGroupProps}>
-          Ja, likt beløp i hele perioden
-        </Radio>
-        <Radio value="JA_VARIERENDE_REFUSJON" {...radioGroupProps}>
-          Ja, men kun deler av perioden eller varierende beløp
-        </Radio>
-        <Radio value="nei" {...radioGroupProps}>
-          Nei
-        </Radio>
-      </RadioGroup>
-      <HjelpetekstReadMore header="Hvilke endringer må du informere NAV om?">
-        <Stack gap="2">
-          <BodyLong>
-            Her skal du registrere endringer som påvirker refusjonen fra NAV.
-          </BodyLong>
-          <BodyLong>
-            Dette kan være på grunn av endret stillingsprosent som gjør at
-            lønnen dere forskutterer endrer seg i perioden
-          </BodyLong>
-          <BodyLong>
-            Hvis dere skal slutte å forskuttere lønn i perioden, registrerer du
-            det som en endring her. Dette kan være fordi arbeidsforholdet
-            opphører, eller fordi dere kun forskutterer en begrenset periode. Du
-            skriver da 0,- i refusjon fra den datoen dere ikke lengre
-            forskutterer lønn.
-          </BodyLong>
-          <BodyLong>
-            Du trenger ikke å informere om endringer fordi den ansatte jobber
-            mer eller mindre i en periode.
-          </BodyLong>
-        </Stack>
-      </HjelpetekstReadMore>
-      {endringIRefusjon === "ja" ? <RefusjonsPerioder /> : undefined}
-    </div>
+    <VStack>
+      <Heading level="2" size="small">
+        Refusjonsbeløp dere krever per måned
+      </Heading>
+      <BodyShort size="medium" spacing textColor="subtle">
+        Skal dere slutte å forskuttere lønn underveis i perioden, skriver du 0,-
+        i refusjon fra datoen dere ikke lengre forskutterer lønn.
+      </BodyShort>
+      <RefusjonsPerioder />
+    </VStack>
   );
 }
+//
+// function Refusjon({ opplysninger }: UtbetalingOgRefusjonProps) {
+//   const { register, formState, watch } =
+//     useFormContext<InntektOgRefusjonForm>();
+//   const { name, ...radioGroupProps } = register("endringIRefusjon", {
+//     required: "Du må svare på dette spørsmålet",
+//     shouldUnregister: true,
+//   });
+//
+//   const [skalEndreBeløp, setSkalEndreBeløp] = useState(false);
+//
+//   const endringIRefusjon = watch("endringIRefusjon");
+//   const refusjonsbeløpPerMåned = watch("refusjonsbeløpPerMåned");
+//   const GRUNNBELØP = useQuery(hentGrunnbeløpOptions()).data;
+//   const refusjonsbeløpPerMånedSomNummer = Number(refusjonsbeløpPerMåned);
+//   const erRefusjonOver6G =
+//     !Number.isNaN(refusjonsbeløpPerMånedSomNummer) &&
+//     refusjonsbeløpPerMånedSomNummer > 6 * GRUNNBELØP;
+//
+//   return (
+//     <div className="bg-bg-subtle p-4 flex flex-col gap-4 rounded-md">
+//       {skalEndreBeløp ? (
+//         <Stack gap="4">
+//           <HStack gap="4">
+//             <TextField
+//               {...register("refusjonsbeløpPerMåned")}
+//               autoFocus
+//               label="Refusjonsbeløp per måned"
+//             />
+//             <Button
+//               className="mt-8"
+//               onClick={() => setSkalEndreBeløp(false)}
+//               variant="tertiary"
+//             >
+//               Tilbakestill
+//             </Button>
+//           </HStack>
+//           {erRefusjonOver6G && (
+//             <Alert variant="info">
+//               NAV utbetaler opptil 6G av årslønnen. Du skal likevel føre opp den
+//               lønnen dere utbetaler til den ansatte i sin helhet.
+//             </Alert>
+//           )}
+//         </Stack>
+//       ) : (
+//         <>
+//           <span>Refusjonsbeløp per måned</span>
+//           <Heading level="3" size="medium">
+//             {formatKroner(refusjonsbeløpPerMåned)}
+//           </Heading>
+//           <Button
+//             className="w-fit"
+//             icon={<PencilIcon />}
+//             iconPosition="left"
+//             onClick={() => setSkalEndreBeløp(true)}
+//             size="small"
+//             variant="secondary"
+//           >
+//             Endre refusjonsbeløp
+//           </Button>
+//         </>
+//       )}
+//       <HjelpetekstReadMore header="Har den ansatte delvis fravær i perioden?">
+//         <BodyLong>
+//           Hvis den ansatte skal kombinere stønad fra NAV med arbeid, vil NAV
+//           redusere utbetalingen ut fra opplysningene fra den ansatte. Du oppgir
+//           derfor den månedslønnen dere utbetaler til den ansatte, uavhengig av
+//           hvor mye den ansatte skal jobbe.
+//         </BodyLong>
+//       </HjelpetekstReadMore>
+//       <RadioGroup
+//         error={formState.errors.endringIRefusjon?.message}
+//         legend="Betaler dere lønn under fraværet og krever refusjon?"
+//         name={name}
+//       >
+//         <Radio value="JA_LIK_REFUSJON" {...radioGroupProps}>
+//           Ja, likt beløp i hele perioden
+//         </Radio>
+//         <Radio value="JA_VARIERENDE_REFUSJON" {...radioGroupProps}>
+//           Ja, men kun deler av perioden eller varierende beløp
+//         </Radio>
+//         <Radio value="nei" {...radioGroupProps}>
+//           Nei
+//         </Radio>
+//       </RadioGroup>
+//       <HjelpetekstReadMore header="Hvilke endringer må du informere NAV om?">
+//         <Stack gap="2">
+//           <BodyLong>
+//             Her skal du registrere endringer som påvirker refusjonen fra NAV.
+//           </BodyLong>
+//           <BodyLong>
+//             Dette kan være på grunn av endret stillingsprosent som gjør at
+//             lønnen dere forskutterer endrer seg i perioden
+//           </BodyLong>
+//           <BodyLong>
+//             Hvis dere skal slutte å forskuttere lønn i perioden, registrerer du
+//             det som en endring her. Dette kan være fordi arbeidsforholdet
+//             opphører, eller fordi dere kun forskutterer en begrenset periode. Du
+//             skriver da 0,- i refusjon fra den datoen dere ikke lengre
+//             forskutterer lønn.
+//           </BodyLong>
+//           <BodyLong>
+//             Du trenger ikke å informere om endringer fordi den ansatte jobber
+//             mer eller mindre i en periode.
+//           </BodyLong>
+//         </Stack>
+//       </HjelpetekstReadMore>
+//       {endringIRefusjon === "ja" ? <RefusjonsPerioder /> : undefined}
+//     </div>
+//   );
+// }
 
 export const ENDRING_I_REFUSJON_TEMPLATE = {
   fom: undefined,
@@ -277,24 +287,25 @@ function RefusjonsPerioder() {
   });
 
   return (
-    <div className="grid grid-cols-[220px_min-content_min-content] gap-4 items-start">
+    <div className="grid grid-cols-[min-content_220px_min-content] gap-6 items-start">
       {fields.map((field, index) => (
         <Fragment key={field.id}>
+          <DatePickerWrapped
+            // hideLabel={index > 0}
+            label="Fra og med"
+            name={`refusjonsendringer.${index}.fom` as const}
+            readOnly={index === 0}
+            rules={{ required: "Må oppgis" }}
+          />
           <TextField
             {...register(`refusjonsendringer.${index}.beløp` as const)}
             error={
               formState.errors?.refusjonsendringer?.[index]?.beløp?.message
             }
-            hideLabel={index > 0}
+            // hideLabel={index > 0}
             inputMode="numeric"
             label={<span>Endret refusjon per måned</span>}
             size="medium"
-          />
-          <DatePickerWrapped
-            hideLabel={index > 0}
-            label="Dato for endring"
-            name={`refusjonsendringer.${index}.fom` as const}
-            rules={{ required: "Må oppgis" }}
           />
           <Button
             aria-label="fjern refusjonsendring"
@@ -307,7 +318,7 @@ function RefusjonsPerioder() {
         </Fragment>
       ))}
       <Button
-        className="w-fit"
+        className="w-fit col-span-2"
         icon={<PlusIcon />}
         iconPosition="left"
         onClick={() => append(ENDRING_I_REFUSJON_TEMPLATE)}

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -211,23 +211,159 @@ declare module '@tanstack/react-router' {
 
 // Create and export the route tree
 
-export const routeTree = rootRoute.addChildren({
-  IdRoute: IdRoute.addChildren({
-    IdDineOpplysningerRoute,
-    IdInntektOgRefusjonRoute,
-    IdKvitteringRoute,
-    IdOppsummeringRoute,
-    IdVisRoute,
-    IdIndexRoute,
-  }),
-  EndreIdRoute,
-  RefusjonOmsorgspengerArbeidsgiver1IntroRoute,
-  RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute,
-  RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute,
-  RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute,
-  RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute,
-  RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute,
-})
+interface IdRouteChildren {
+  IdDineOpplysningerRoute: typeof IdDineOpplysningerRoute
+  IdInntektOgRefusjonRoute: typeof IdInntektOgRefusjonRoute
+  IdKvitteringRoute: typeof IdKvitteringRoute
+  IdOppsummeringRoute: typeof IdOppsummeringRoute
+  IdVisRoute: typeof IdVisRoute
+  IdIndexRoute: typeof IdIndexRoute
+}
+
+const IdRouteChildren: IdRouteChildren = {
+  IdDineOpplysningerRoute: IdDineOpplysningerRoute,
+  IdInntektOgRefusjonRoute: IdInntektOgRefusjonRoute,
+  IdKvitteringRoute: IdKvitteringRoute,
+  IdOppsummeringRoute: IdOppsummeringRoute,
+  IdVisRoute: IdVisRoute,
+  IdIndexRoute: IdIndexRoute,
+}
+
+const IdRouteWithChildren = IdRoute._addFileChildren(IdRouteChildren)
+
+export interface FileRoutesByFullPath {
+  '/$id': typeof IdRouteWithChildren
+  '/$id/dine-opplysninger': typeof IdDineOpplysningerRoute
+  '/$id/inntekt-og-refusjon': typeof IdInntektOgRefusjonRoute
+  '/$id/kvittering': typeof IdKvitteringRoute
+  '/$id/oppsummering': typeof IdOppsummeringRoute
+  '/$id/vis': typeof IdVisRoute
+  '/endre/$id': typeof EndreIdRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/1-intro': typeof RefusjonOmsorgspengerArbeidsgiver1IntroRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/2-ansatt-og-arbeidsgiver': typeof RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/3-omsorgsdager': typeof RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/4-refusjon': typeof RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/5-oppsummering': typeof RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/6-kvittering': typeof RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute
+  '/$id/': typeof IdIndexRoute
+}
+
+export interface FileRoutesByTo {
+  '/$id/dine-opplysninger': typeof IdDineOpplysningerRoute
+  '/$id/inntekt-og-refusjon': typeof IdInntektOgRefusjonRoute
+  '/$id/kvittering': typeof IdKvitteringRoute
+  '/$id/oppsummering': typeof IdOppsummeringRoute
+  '/$id/vis': typeof IdVisRoute
+  '/endre/$id': typeof EndreIdRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/1-intro': typeof RefusjonOmsorgspengerArbeidsgiver1IntroRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/2-ansatt-og-arbeidsgiver': typeof RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/3-omsorgsdager': typeof RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/4-refusjon': typeof RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/5-oppsummering': typeof RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/6-kvittering': typeof RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute
+  '/$id': typeof IdIndexRoute
+}
+
+export interface FileRoutesById {
+  __root__: typeof rootRoute
+  '/$id': typeof IdRouteWithChildren
+  '/$id/dine-opplysninger': typeof IdDineOpplysningerRoute
+  '/$id/inntekt-og-refusjon': typeof IdInntektOgRefusjonRoute
+  '/$id/kvittering': typeof IdKvitteringRoute
+  '/$id/oppsummering': typeof IdOppsummeringRoute
+  '/$id/vis': typeof IdVisRoute
+  '/endre/$id': typeof EndreIdRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/1-intro': typeof RefusjonOmsorgspengerArbeidsgiver1IntroRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/2-ansatt-og-arbeidsgiver': typeof RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/3-omsorgsdager': typeof RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/4-refusjon': typeof RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/5-oppsummering': typeof RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute
+  '/refusjon-omsorgspenger-arbeidsgiver/6-kvittering': typeof RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute
+  '/$id/': typeof IdIndexRoute
+}
+
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/$id'
+    | '/$id/dine-opplysninger'
+    | '/$id/inntekt-og-refusjon'
+    | '/$id/kvittering'
+    | '/$id/oppsummering'
+    | '/$id/vis'
+    | '/endre/$id'
+    | '/refusjon-omsorgspenger-arbeidsgiver/1-intro'
+    | '/refusjon-omsorgspenger-arbeidsgiver/2-ansatt-og-arbeidsgiver'
+    | '/refusjon-omsorgspenger-arbeidsgiver/3-omsorgsdager'
+    | '/refusjon-omsorgspenger-arbeidsgiver/4-refusjon'
+    | '/refusjon-omsorgspenger-arbeidsgiver/5-oppsummering'
+    | '/refusjon-omsorgspenger-arbeidsgiver/6-kvittering'
+    | '/$id/'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/$id/dine-opplysninger'
+    | '/$id/inntekt-og-refusjon'
+    | '/$id/kvittering'
+    | '/$id/oppsummering'
+    | '/$id/vis'
+    | '/endre/$id'
+    | '/refusjon-omsorgspenger-arbeidsgiver/1-intro'
+    | '/refusjon-omsorgspenger-arbeidsgiver/2-ansatt-og-arbeidsgiver'
+    | '/refusjon-omsorgspenger-arbeidsgiver/3-omsorgsdager'
+    | '/refusjon-omsorgspenger-arbeidsgiver/4-refusjon'
+    | '/refusjon-omsorgspenger-arbeidsgiver/5-oppsummering'
+    | '/refusjon-omsorgspenger-arbeidsgiver/6-kvittering'
+    | '/$id'
+  id:
+    | '__root__'
+    | '/$id'
+    | '/$id/dine-opplysninger'
+    | '/$id/inntekt-og-refusjon'
+    | '/$id/kvittering'
+    | '/$id/oppsummering'
+    | '/$id/vis'
+    | '/endre/$id'
+    | '/refusjon-omsorgspenger-arbeidsgiver/1-intro'
+    | '/refusjon-omsorgspenger-arbeidsgiver/2-ansatt-og-arbeidsgiver'
+    | '/refusjon-omsorgspenger-arbeidsgiver/3-omsorgsdager'
+    | '/refusjon-omsorgspenger-arbeidsgiver/4-refusjon'
+    | '/refusjon-omsorgspenger-arbeidsgiver/5-oppsummering'
+    | '/refusjon-omsorgspenger-arbeidsgiver/6-kvittering'
+    | '/$id/'
+  fileRoutesById: FileRoutesById
+}
+
+export interface RootRouteChildren {
+  IdRoute: typeof IdRouteWithChildren
+  EndreIdRoute: typeof EndreIdRoute
+  RefusjonOmsorgspengerArbeidsgiver1IntroRoute: typeof RefusjonOmsorgspengerArbeidsgiver1IntroRoute
+  RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute: typeof RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute
+  RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute: typeof RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute
+  RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute: typeof RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute
+  RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute: typeof RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute
+  RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute: typeof RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute
+}
+
+const rootRouteChildren: RootRouteChildren = {
+  IdRoute: IdRouteWithChildren,
+  EndreIdRoute: EndreIdRoute,
+  RefusjonOmsorgspengerArbeidsgiver1IntroRoute:
+    RefusjonOmsorgspengerArbeidsgiver1IntroRoute,
+  RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute:
+    RefusjonOmsorgspengerArbeidsgiver2AnsattOgArbeidsgiverRoute,
+  RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute:
+    RefusjonOmsorgspengerArbeidsgiver3OmsorgsdagerRoute,
+  RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute:
+    RefusjonOmsorgspengerArbeidsgiver4RefusjonRoute,
+  RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute:
+    RefusjonOmsorgspengerArbeidsgiver5OppsummeringRoute,
+  RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute:
+    RefusjonOmsorgspengerArbeidsgiver6KvitteringRoute,
+}
+
+export const routeTree = rootRoute
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
 /* prettier-ignore-end */
 

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -44,7 +44,7 @@ export const Route = createFileRoute("/$id/inntekt-og-refusjon")({
 type JaNei = "ja" | "nei";
 
 export type InntektOgRefusjonForm = {
-  skalRefunderes: JaNei;
+  skalRefunderes: "JA_LIK_REFUSJON" | "JA_VARIERENDE_REFUSJON" | "NEI";
   endringIRefusjon: JaNei;
   misterNaturalytelser: JaNei;
   naturalytelserSomMistes: NaturalytelserSomMistesForm[];

--- a/app/src/routes/$id.inntekt-og-refusjon.tsx
+++ b/app/src/routes/$id.inntekt-og-refusjon.tsx
@@ -18,10 +18,7 @@ import {
   NATURALYTELSE_SOM_MISTES_TEMPLATE,
   Naturalytelser,
 } from "~/features/skjema-moduler/Naturalytelser";
-import {
-  ENDRING_I_REFUSJON_TEMPLATE,
-  UtbetalingOgRefusjon,
-} from "~/features/skjema-moduler/UtbetalingOgRefusjon.tsx";
+import { UtbetalingOgRefusjon } from "~/features/skjema-moduler/UtbetalingOgRefusjon.tsx";
 import type { OpplysningerDto } from "~/types/api-models.ts";
 import { Naturalytelsetype } from "~/types/api-models.ts";
 import {
@@ -45,7 +42,6 @@ type JaNei = "ja" | "nei";
 
 export type InntektOgRefusjonForm = {
   skalRefunderes: "JA_LIK_REFUSJON" | "JA_VARIERENDE_REFUSJON" | "NEI";
-  endringIRefusjon: JaNei;
   misterNaturalytelser: JaNei;
   naturalytelserSomMistes: NaturalytelserSomMistesForm[];
 } & Pick<
@@ -74,21 +70,18 @@ function InntektOgRefusjon() {
     opplysninger.inntekter,
   );
 
+  const inntekt =
+    inntektsmeldingSkjemaState.inntekt || gjennomsnikkInntektFraAOrdning;
+
   const formMethods = useForm<InntektOgRefusjonForm>({
     defaultValues: {
       // Denne ligger i formet, men brukes ikke annet enn for submit
-      inntekt:
-        inntektsmeldingSkjemaState.inntekt || gjennomsnikkInntektFraAOrdning,
+      inntekt,
       inntektEndringsÅrsak: inntektsmeldingSkjemaState.inntektEndringsÅrsak,
       refusjonsbeløpPerMåned:
         inntektsmeldingSkjemaState.refusjonsbeløpPerMåned ||
         gjennomsnikkInntektFraAOrdning,
-      skalRefunderes: konverterTilRadioValg(
-        inntektsmeldingSkjemaState.skalRefunderes,
-      ),
-      endringIRefusjon: konverterTilRadioValg(
-        inntektsmeldingSkjemaState.endringIRefusjon,
-      ),
+      skalRefunderes: inntektsmeldingSkjemaState.skalRefunderes,
       misterNaturalytelser: konverterTilRadioValg(
         inntektsmeldingSkjemaState.misterNaturalytelser,
       ),
@@ -103,7 +96,7 @@ function InntektOgRefusjon() {
             ),
       refusjonsendringer:
         inntektsmeldingSkjemaState.refusjonsendringer.length === 0
-          ? [ENDRING_I_REFUSJON_TEMPLATE]
+          ? [{ fom: opplysninger.startdatoPermisjon, beløp: inntekt }]
           : inntektsmeldingSkjemaState.refusjonsendringer,
     },
   });
@@ -111,13 +104,17 @@ function InntektOgRefusjon() {
   const navigate = useNavigate();
 
   const onSubmit = handleSubmit((skjemadata) => {
-    const { refusjonsbeløpPerMåned, inntekt, inntektEndringsÅrsak } =
-      skjemadata;
-    const skalRefunderes = skjemadata.skalRefunderes === "ja";
-    const endringIRefusjon = skjemadata.endringIRefusjon === "ja";
-    const refusjonsendringer = endringIRefusjon
-      ? skjemadata.refusjonsendringer
-      : [];
+    const {
+      refusjonsbeløpPerMåned,
+      inntekt,
+      inntektEndringsÅrsak,
+      skalRefunderes,
+    } = skjemadata;
+
+    const refusjonsendringer =
+      skalRefunderes === "JA_VARIERENDE_REFUSJON"
+        ? skjemadata.refusjonsendringer
+        : [];
 
     const misterNaturalytelser = skjemadata.misterNaturalytelser === "ja";
     const naturalytelserSomMistes = misterNaturalytelser
@@ -133,7 +130,6 @@ function InntektOgRefusjon() {
       inntektEndringsÅrsak,
       refusjonsbeløpPerMåned,
       skalRefunderes,
-      endringIRefusjon,
       refusjonsendringer,
       misterNaturalytelser,
       naturalytelserSomMistes,
@@ -157,7 +153,7 @@ function InntektOgRefusjon() {
           <Fremgangsindikator aktivtSteg={2} />
           <Ytelsesperiode opplysninger={opplysninger} />
           <Inntekt opplysninger={opplysninger} />
-          <UtbetalingOgRefusjon opplysninger={opplysninger} />
+          <UtbetalingOgRefusjon />
           <Naturalytelser />
           <div className="flex gap-4 justify-center">
             <Button

--- a/app/src/views/shared/Skjemaoppsummering.tsx
+++ b/app/src/views/shared/Skjemaoppsummering.tsx
@@ -176,11 +176,10 @@ export const Skjemaoppsummering = ({
               Vil det være endringer i refusjon i løpet av perioden{" "}
               {opplysninger.person.fornavn} er i permisjon?
             </FormSummary.Label>
-            <FormSummary.Value>
-              {skjemaState.endringIRefusjon ? "Ja" : "Nei"}
-            </FormSummary.Value>
+            <FormSummary.Value>{skjemaState.skalRefunderes}</FormSummary.Value>{" "}
+            {/*// TODO: map*/}
           </FormSummary.Answer>
-          {skjemaState.endringIRefusjon && (
+          {skjemaState.skalRefunderes === "JA_VARIERENDE_REFUSJON" && (
             <FormSummary.Answer>
               <FormSummary.Label>Endringer i refusjon</FormSummary.Label>
               <FormSummary.Value>

--- a/app/src/views/shared/Skjemaoppsummering.tsx
+++ b/app/src/views/shared/Skjemaoppsummering.tsx
@@ -2,6 +2,7 @@ import { FormSummary, VStack } from "@navikt/ds-react";
 import { Link } from "@tanstack/react-router";
 
 import { InntektsmeldingSkjemaStateValid } from "~/features/InntektsmeldingSkjemaState";
+import { REFUSJON_RADIO_VALG } from "~/features/skjema-moduler/UtbetalingOgRefusjon.tsx";
 import { ÅrsaksType } from "~/types/api-models";
 import type { OpplysningerDto } from "~/types/api-models.ts";
 import {
@@ -156,14 +157,13 @@ export const Skjemaoppsummering = ({
         <FormSummary.Answers>
           <FormSummary.Answer>
             <FormSummary.Label>
-              Skal dere betale lønn til {opplysninger.person.fornavn} og ha
-              refusjon fra NAV?
+              Betaler dere lønn under fraværet og krever refusjon?
             </FormSummary.Label>
             <FormSummary.Value>
-              {skjemaState.skalRefunderes ? "Ja" : "Nei"}
+              {REFUSJON_RADIO_VALG[skjemaState.skalRefunderes]}
             </FormSummary.Value>
           </FormSummary.Answer>
-          {skjemaState.skalRefunderes && (
+          {skjemaState.skalRefunderes === "JA_LIK_REFUSJON" && (
             <FormSummary.Answer>
               <FormSummary.Label>Refusjonsbeløp per måned</FormSummary.Label>
               <FormSummary.Value>
@@ -171,14 +171,6 @@ export const Skjemaoppsummering = ({
               </FormSummary.Value>
             </FormSummary.Answer>
           )}
-          <FormSummary.Answer>
-            <FormSummary.Label>
-              Vil det være endringer i refusjon i løpet av perioden{" "}
-              {opplysninger.person.fornavn} er i permisjon?
-            </FormSummary.Label>
-            <FormSummary.Value>{skjemaState.skalRefunderes}</FormSummary.Value>{" "}
-            {/*// TODO: map*/}
-          </FormSummary.Answer>
           {skjemaState.skalRefunderes === "JA_VARIERENDE_REFUSJON" && (
             <FormSummary.Answer>
               <FormSummary.Label>Endringer i refusjon</FormSummary.Label>

--- a/app/tests/e2e/happy-path.spec.tsx
+++ b/app/tests/e2e/happy-path.spec.tsx
@@ -25,7 +25,7 @@ test.describe("Happy path", () => {
     await page.getByRole("button", { name: "Bekreft og gå videre" }).click();
 
     // Nå er vi på "inntekt og refusjon" steget
-    await page.locator('input[name="skalRefunderes"][value="nei"]').click();
+    await page.locator('input[name="skalRefunderes"][value="NEI"]').click();
 
     await page
       .locator('input[name="misterNaturalytelser"][value="nei"]')


### PR DESCRIPTION
Endrer til at refusjon har 3 radio valg for å slippe nøstede radiogrupper.

Se nytt design [her](https://www.figma.com/design/34Ki9QKZRlOuzRkxTGNvvb/Ny-inntektmelding-PO-familie?node-id=2619-87445&node-type=frame&t=bRKGtQ2nbKEtO109-0)