### PR TITLE
Legg til 'og' etter komma i en hjelpetekst

### DIFF
--- a/app/src/features/inntektsmelding/Steg2InntektOgRefusjon.tsx
+++ b/app/src/features/inntektsmelding/Steg2InntektOgRefusjon.tsx
@@ -218,7 +218,7 @@ function Ytelsesperiode() {
           Dette er den første dagen den ansatte har søkt om{" "}
           {formatYtelsesnavn(ytelse)}. Det betyr at NAV trenger opplysninger om
           den ansattes inntekt på denne datoen. Vi baserer oss på datoen som er
-          oppgitt i søknaden, du kan derfor ikke endre denne i
+          oppgitt i søknaden, og du kan derfor ikke endre denne i
           inntektsmeldingen. <br />
           <br />
           Hvis du er usikker på om dette er riktig dato for første fraværsdag,


### PR DESCRIPTION
Det manglet et "og", så denne PRen legger til det.

> Et komma står der, klart men stumt,
> hjelpetekstens rytme, nesten dumt.
> Nav ber om inntekt, rett tid må du se,
> men noe mangler, hva kan det være med?
> 
> Et lite "og" er glemt på sin plass,
> mellom setninger, uten jazz og stas.
> Uten det lille ord, alt står på vent,
> som en bil på tomgang, nesten hendt.
> 
> Så la oss legge det til, enkelt og kjært,
> hjelpen er tydelig, klart som vi lærte.
> Nav skal ha inntekt, tidspunkt og mer,
> med et "og" på plass, alt er nå her!