### PR TITLE
Endre kilde på kontaktinformasjon

### DIFF
--- a/app/src/features/inntektsmelding/Steg1DineOpplysninger.tsx
+++ b/app/src/features/inntektsmelding/Steg1DineOpplysninger.tsx
@@ -75,7 +75,7 @@ export const Steg1DineOpplysninger = () => {
           <Personinformasjon opplysninger={opplysninger} />
           <Informasjonsseksjon
             className="col-span-2"
-            kilde="Fra Altinn"
+            kilde="Fra Altinn og Folkeregisteret"
             tittel="Kontaktinformasjon for arbeidsgiver"
           >
             <HGrid align="start" columns={{ sm: 1, md: 2 }} gap="5">

--- a/app/src/features/refusjon-omsorgspenger-arbeidsgiver/Steg2AnsattOgArbeidsgiver.tsx
+++ b/app/src/features/refusjon-omsorgspenger-arbeidsgiver/Steg2AnsattOgArbeidsgiver.tsx
@@ -123,7 +123,10 @@ export const RefusjonOmsorgspengerArbeidsgiverSteg2 = () => {
             )}
           </Informasjonsseksjon>
         )}
-        <Informasjonsseksjon kilde="Fra Altinn" tittel="Kontaktinformasjon">
+        <Informasjonsseksjon
+          kilde="Fra Altinn og Folkeregisteret"
+          tittel="Kontaktinformasjon"
+        >
           <div className="flex gap-4 flex-col md:flex-row">
             <div className="flex-1">
               <TextField


### PR DESCRIPTION
Det viser seg at vi henter informasjon fra både Altinn og Folkeregisteret i kontaktsteget.