### PR TITLE
Legg til en bundle visualizer, så man kan se hva som tar plass

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "stylelint": "stylelint '**/*.{tsx,css}'",
-    "stylelint:fix": "stylelint --fix '**/*.{tsx,css}'"
+    "stylelint:fix": "stylelint --fix '**/*.{tsx,css}'",
+    "bundle-visualizer": "npx vite-bundle-visualizer"
   },
   "dependencies": {
     "@navikt/aksel-icons": "^7.2.1",


### PR DESCRIPTION
Det kan være nyttig å se hva som tar plass i bundlen vår når man skal optimalisere. Denne PRen legger til en `npm run visualize` kommando, som åpner et interaktivt vindu hvor du kan utforske størrelser.

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/f78acb6d-c3a8-4372-9808-383f6f3ea65e">

Hvem skulle trodd at Zod var så stort?