### PR TITLE
Legg til manglende slæsj

### DIFF
--- a/app/src/settOppGrafanaFaro.ts
+++ b/app/src/settOppGrafanaFaro.ts
@@ -15,7 +15,7 @@ function lagGrafanaAppName() {
   if (import.meta.env.BASE_URL === "/fp-im-dialog") {
     return "fpinntektsmelding-frontend";
   }
-  if (import.meta.env.BASE_URL === "k9-im-dialog") {
+  if (import.meta.env.BASE_URL === "/k9-im-dialog") {
     return "k9-inntektsmelding-frontend";
   }
 


### PR DESCRIPTION
Manglet en slash i en URL, gjorde at k9-inntektsmeldinger ikke fungerte som ønsket.