### PR TITLE
Vis frem inntektsmelding om den er tilgjengelig når oppgaven er utgått

### DIFF
--- a/app/src/features/inntektsmelding/Steg3Oppsummering.tsx
+++ b/app/src/features/inntektsmelding/Steg3Oppsummering.tsx
@@ -84,6 +84,11 @@ function SendInnInntektsmelding({ opplysninger }: SendInnInntektsmeldingProps) {
 
   const { mutate, error, isPending } = useMutation({
     mutationFn: async (skjemaState: InntektsmeldingSkjemaStateValid) => {
+      if (opplysninger.forespørselStatus === "UTGÅTT") {
+        throw new Error(
+          "Du kan ikke sende inn en ny inntektsmelding når oppgaven den er knyttet til er utgått.",
+        );
+      }
       const inntektsmeldingRequest = lagSendInntektsmeldingRequest(
         id,
         skjemaState,

--- a/app/src/features/inntektsmelding/VisInntektsmelding.tsx
+++ b/app/src/features/inntektsmelding/VisInntektsmelding.tsx
@@ -1,5 +1,13 @@
 import { DownloadIcon, PencilIcon } from "@navikt/aksel-icons";
-import { Button, Detail, Heading, HStack, VStack } from "@navikt/ds-react";
+import {
+  Alert,
+  BodyShort,
+  Button,
+  Detail,
+  Heading,
+  HStack,
+  VStack,
+} from "@navikt/ds-react";
 import { getRouteApi, Link } from "@tanstack/react-router";
 import { useEffect } from "react";
 
@@ -35,6 +43,7 @@ export const VisInntektsmelding = () => {
     <Button
       as={Link}
       className="w-fit"
+      disabled={opplysninger.forespørselStatus === "UTGÅTT"}
       icon={<PencilIcon />}
       to="../dine-opplysninger"
       variant="secondary"
@@ -60,6 +69,15 @@ export const VisInntektsmelding = () => {
           </VStack>
           {endreKnapp}
         </HStack>
+        {opplysninger.forespørselStatus === "UTGÅTT" && (
+          <Alert className="my-4" variant="warning">
+            <BodyShort>
+              Du kan ikke endre inntektsmeldingen når oppgaven den er knyttet
+              til er utgått. Det kan skje når søkeren trekker søknaden sin etter
+              man har sendt inn en inntektsmelding for den søknaden.
+            </BodyShort>
+          </Alert>
+        )}
         <Skjemaoppsummering
           opplysninger={opplysninger}
           skjemaState={sisteInntektsmelding}

--- a/app/src/routes/$id.tsx
+++ b/app/src/routes/$id.tsx
@@ -36,7 +36,10 @@ export const Route = createFileRoute("/$id")({
       hentEksisterendeInntektsmeldinger(params.id),
     ]);
 
-    if (opplysninger.forespørselStatus === "UTGÅTT") {
+    if (
+      opplysninger.forespørselStatus === "UTGÅTT" &&
+      eksisterendeInntektsmeldinger.length === 0
+    ) {
       throw new Error(FEILKODER.OPPGAVE_ER_UTGÅTT);
     }
 


### PR DESCRIPTION
Om en oppgave er markert som utgått etter en inntektsmelding er sendt inn, skal man fortsatt kunne se inntektsmeldingen man sendte inn. Forskjellen er at man ikke skal kunne endre den. 

Denne PRen legger til rette for det.