### PR TITLE
Pofim 128 nedetid ainntekt

### DIFF
--- a/app/src/features/skjema-moduler/Inntekt.tsx
+++ b/app/src/features/skjema-moduler/Inntekt.tsx
@@ -118,8 +118,8 @@ export function Inntekt({
       {/* Hvis A-inntekt må feltet fylles ut, og det er ingen tilbakestillingsknapp. */}
       {AInntektErNede ? (
         <FormattertTallTextField
-          htmlSize={20}
           description={gjennomsnittAvMånederTekst}
+          htmlSize={20}
           inputMode="numeric"
           label="Beregnet måndslønn"
           min={0}

--- a/app/src/features/skjema-moduler/Inntekt.tsx
+++ b/app/src/features/skjema-moduler/Inntekt.tsx
@@ -65,6 +65,15 @@ export function Inntekt({
   );
   const førsteDag = formatDatoKort(new Date(skjæringstidspunkt));
 
+  const gjennomsnittAvMånederTekst = `Gjennomsnittet av lønn fra 
+  ${formatOppramsing(
+    inntektsopplysninger.månedsinntekter
+      .filter(
+        (m) => m.status !== "IKKE_RAPPORTERT_RAPPORTERINGSFRIST_IKKE_PASSERT",
+      )
+      .map((m) => navnPåMåned(m.fom).toLowerCase()),
+  )}`;
+
   return (
     <div className="flex flex-col gap-4">
       <hr />
@@ -92,39 +101,27 @@ export function Inntekt({
         </HGrid>
       </Informasjonsseksjon>
 
-      <VStack data-testid="gjennomsnittinntekt-block" gap="1">
-        {!AInntektErNede && (
-          <>
-            <BodyShort>Beregnet månedslønn</BodyShort>
-            <strong
-              className={clsx(
-                "text-heading-medium",
-                isOpen && "text-text-subtle line-through",
-              )}
-            >
-              {formatKroner(inntektsopplysninger.gjennomsnittLønn)}
-            </strong>
-          </>
-        )}
-        <BodyShort>
-          Gjennomsnittet av lønn fra{" "}
-          {formatOppramsing(
-            inntektsopplysninger.månedsinntekter
-              .filter(
-                (m) =>
-                  m.status !==
-                  "IKKE_RAPPORTERT_RAPPORTERINGSFRIST_IKKE_PASSERT",
-              )
-              .map((m) => navnPåMåned(m.fom).toLowerCase()),
-          )}
-        </BodyShort>
-      </VStack>
+      {!AInntektErNede && (
+        <VStack data-testid="gjennomsnittinntekt-block" gap="1">
+          <BodyShort>Beregnet månedslønn</BodyShort>
+          <strong
+            className={clsx(
+              "text-heading-medium",
+              isOpen && "text-text-subtle line-through",
+            )}
+          >
+            {formatKroner(inntektsopplysninger.gjennomsnittLønn)}
+          </strong>
+          <BodyShort>{gjennomsnittAvMånederTekst}</BodyShort>
+        </VStack>
+      )}
       {/* Hvis A-inntekt må feltet fylles ut, og det er ingen tilbakestillingsknapp. */}
       {AInntektErNede ? (
         <FormattertTallTextField
-          className="w-fit"
+          htmlSize={20}
+          description={gjennomsnittAvMånederTekst}
           inputMode="numeric"
-          label="Beregned måndslønn"
+          label="Beregnet måndslønn"
           min={0}
           name="korrigertInntekt"
           required

--- a/app/src/types/api-models.ts
+++ b/app/src/types/api-models.ts
@@ -130,7 +130,7 @@ export const opplysningerSchema = z.object({
     organisasjonNummer: z.string(),
   }),
   inntektsopplysninger: z.object({
-    gjennomsnittLønn: z.number(),
+    gjennomsnittLønn: z.number().optional(),
     månedsinntekter: z.array(
       z.object({
         fom: z.string(),

--- a/app/src/types/api-models.ts
+++ b/app/src/types/api-models.ts
@@ -137,6 +137,7 @@ export const opplysningerSchema = z.object({
         tom: z.string(),
         beløp: z.number().optional(),
         status: z.enum([
+          "NEDETID_AINNTEKT",
           "BRUKT_I_GJENNOMSNITT",
           "IKKE_RAPPORTERT_MEN_BRUKT_I_GJENNOMSNITT",
           "IKKE_RAPPORTERT_RAPPORTERINGSFRIST_IKKE_PASSERT",

--- a/app/tests/e2e/foreslått-inntekt.spec.tsx
+++ b/app/tests/e2e/foreslått-inntekt.spec.tsx
@@ -7,6 +7,7 @@ import {
 
 import {
   enkeltOpplysningerResponse,
+  opplysningerMedAInntektNede,
   opplysningerMedBådeRapportertOgIkkePassert,
   opplysningerMedFlereEnn3Måneder,
   opplysningerMedSisteMånedIkkeRapportertFørRapporteringsfrist,
@@ -210,6 +211,47 @@ test("[??.??] siste måned ikke passert, nest siste passert", async ({
     beregnetMånedslønn.getByTestId(
       "alert-både-ikke-rapportert-og-brukt-i-snitt",
     ),
+  ).toBeVisible({ visible: true });
+  await expect(
+    beregnetMånedslønn.getByTestId("alert-ikke-rapportert-frist-ikke-passert"),
+  ).toBeVisible({ visible: false });
+});
+
+test("A-inntekt er nede", async ({ page }) => {
+  await mockOpplysninger({
+    page,
+    json: opplysningerMedAInntektNede,
+  });
+  await mockGrunnbeløp({ page });
+  await mockInntektsmeldinger({
+    page,
+  });
+
+  await page.goto("/fp-im-dialog/1/inntekt-og-refusjon");
+
+  const beregnetMånedslønn = page
+    .getByRole("heading", { name: "Beregnet månedslønn" })
+    .locator("..");
+
+  await expect(beregnetMånedslønn.getByText("Februar:-")).toBeVisible();
+  await expect(beregnetMånedslønn.getByText("Mars:-")).toBeVisible();
+  await expect(beregnetMånedslønn.getByText("April:-")).toBeVisible();
+  await expect(page.getByTestId("gjennomsnittinntekt-block")).toBeVisible({
+    visible: false,
+  });
+  await expect(
+    page
+      .getByTestId("gjennomsnittinntekt-block")
+      .getByText("Gjennomsnittet av lønn fra februar, mars og april"),
+  ).toBeVisible();
+
+  await page.getByLabel("Beregnet måndslønn").fill("34000");
+
+  await expect(
+    beregnetMånedslønn.getByTestId("alert-ikke-rapportert-brukt-i-snitt"),
+  ).toBeVisible({ visible: false });
+  await expect(
+    beregnetMånedslønn.getByTestId("alert-a-inntekt-er-nede"),
   ).toBeVisible({ visible: true });
   await expect(
     beregnetMånedslønn.getByTestId("alert-ikke-rapportert-frist-ikke-passert"),

--- a/app/tests/e2e/foreslått-inntekt.spec.tsx
+++ b/app/tests/e2e/foreslått-inntekt.spec.tsx
@@ -240,9 +240,7 @@ test("A-inntekt er nede", async ({ page }) => {
     visible: false,
   });
   await expect(
-    page
-      .getByTestId("gjennomsnittinntekt-block")
-      .getByText("Gjennomsnittet av lønn fra februar, mars og april"),
+    page.getByText("Gjennomsnittet av lønn fra februar, mars og april"),
   ).toBeVisible();
 
   await page.getByLabel("Beregnet måndslønn").fill("34000");

--- a/app/tests/mocks/opplysninger.ts
+++ b/app/tests/mocks/opplysninger.ts
@@ -109,6 +109,29 @@ export const opplysningerMedSisteMånedRapportert0 = {
   },
 } satisfies OpplysningerDto;
 
+export const opplysningerMedAInntektNede = {
+  ...STANDARD_OPPLYSNINGER,
+  inntektsopplysninger: {
+    månedsinntekter: [
+      {
+        fom: "2024-02-01",
+        tom: "2024-02-29",
+        status: "NEDETID_AINNTEKT",
+      },
+      {
+        fom: "2024-03-01",
+        tom: "2024-03-31",
+        status: "NEDETID_AINNTEKT",
+      },
+      {
+        fom: "2024-04-01",
+        tom: "2024-04-30",
+        status: "NEDETID_AINNTEKT",
+      },
+    ],
+  },
+} satisfies OpplysningerDto;
+
 export const opplysningerMedFlereEnn3Måneder = {
   ...STANDARD_OPPLYSNINGER,
   skjæringstidspunkt: "2024-05-04",


### PR DESCRIPTION
Implementerer et litt annet design når a-inntekt er nede. Det kommer som en ny status på inntekt fra backend.

https://www.figma.com/design/34Ki9QKZRlOuzRkxTGNvvb/Ny-inntektmelding-PO-familie?node-id=3733-51900&node-type=frame&t=PeK0VV0tLCmu7lWT-0

I disse tilfellene er "Beregnet månedslønn" inputfeltet alltid tilgjengelig